### PR TITLE
READY : Extend rule for keyword spacing

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -109,6 +109,7 @@ rules :
       before : false
       after : false
       overrides :
+        of : { 'before' : true }
         return : { 'after' : true }
         let : { 'after' : true }
         const : { 'after' : true }


### PR DESCRIPTION
It enables spacing before keyword of in cycle for-of. Now, ESlint finds error when code looks like :
```js
for( let [ key, value ] of container ] ) 
```
and should not