### PR TITLE
READY : Cover `strSplitsQuotedRejoin`

### DIFF
--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9649,6 +9649,25 @@ function strSplitsUngroupedJoin( test )
 function strSplitsQuotedRejoin( test )
 {
 
+  test.case = 'empty splits';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [];
+  test.identical( splits, expected );
+
+  /* */
+
   test.case = 'basic';
 
   var delimeter = [ '<', '>' ];
@@ -9924,6 +9943,25 @@ function strSplitsQuotedRejoin( test )
 
 function strSplitsQuotedRejoinOptionOnQuoting( test )
 {
+
+  test.case = 'empty splits, return +';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => '+'
+  });
+  var expected = [];
+  test.identical( splits, expected );
+
   test.case = 'basic, add strings';
 
   var delimeter = [ '<', '>' ];

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9668,6 +9668,25 @@ function strSplitsQuotedRejoin( test )
   var expected = [ `<r1>`, `<r2>` ];
   test.identical( splits, expected );
 
+  test.case = 'basic2';
+
+  var delimeter = [ '-', '+' ];
+  var splits = [ `-`, `r1`, `+`, `-`, `r2`, `+` ];
+  debugger;
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '-' ],
+    quotingPostfixes : [ '+' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  debugger;
+  var expected = [ `-r1+`, `-r2+` ];
+  test.identical( splits, expected );
+
 }
 
 // --

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9666,7 +9666,7 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
-  test.case = 'default quotingPrefixes, quotingPostfixes; no delimeter';
+  test.case = 'default quotingPrefixes, quotingPostfixes';
 
   var splits = [ `"`, `r1`, `"`, `"`, `r2`, `"` ];
   _.strSplitsQuotedRejoin
@@ -9755,6 +9755,23 @@ function strSplitsQuotedRejoin( test )
     inliningQuoting : 0,
   });
   var expected = [ `r1`, `r2` ];
+
+  /* */
+
+  test.case = 'basic, prefix and postfix have different lengths';
+
+  var splits = [ `<<`, `r1`, `>>>`, `<<`, `r2`, `>>>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    quotingPrefixes : [ '<<', ],
+    quotingPostfixes : [ '>>>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<<r1>>>`, `<<r2>>>` ];
+  test.identical( splits, expected );
 
   /* */
 

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9758,6 +9758,41 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
+  test.case = 'basic, o.pairing : 1, prefix and postfix are the same';
+
+  var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '<' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1<`, `<r2<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix and postfix are NOT the same';
+
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  var result = _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  test.identical( result, undefined );
+
+  /* */
+
   test.case = 'basic, prefix and postfix have different lengths';
 
   var splits = [ `<<`, `r1`, `>>>`, `<<`, `r2`, `>>>` ];
@@ -10020,6 +10055,20 @@ function strSplitsQuotedRejoin( test )
   test.shouldThrowErrorSync( function()
   {
     _.strSplitsQuotedRejoin( 13 );
+  });
+
+  test.case = 'o.pairing : 1, o.quotingPrefixes.length !== o.quotingPostfixes.length';
+  test.shouldThrowErrorSync( function()
+  {
+    _.strSplitsQuotedRejoin
+    ({
+      splits : [ '<<', 'a', '>' ],
+      quoting : 1,
+      quotingPrefixes : [ '<', '<<' ],
+      quotingPostfixes : [ '>' ],
+      preservingQuoting : 1,
+      inliningQuoting : 0,
+    });
   });
 
 }

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9916,6 +9916,25 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ] = postfix[ 1 ] prefix[ 1 ] = postfix[ 0 ]';
+  var delimeter = [ '<', '"' ];
+  var splits = [ `<`, `r1`, `>`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<', '"' ],
+    quotingPostfixes : [ '"', '<' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '<', 'r1', '>', '"', 'r2', '"' ];
+  test.identical( splits, expected );
+
+  /* */
+
   test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, first el withot quoting';
   var splits = [ `r1`, `"`, `r2`, `"` ];
   _.strSplitsQuotedRejoin
@@ -9950,7 +9969,7 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
-  test.case = 'prefix & postfix are the same';
+  test.case = 'prefix & postfix are custom & the same';
 
   var delimeter = [ '-' ];
   var splits = [ `-`, `r1`, `-`, `-`, `r2`, `-` ];

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9651,8 +9651,59 @@ function strSplitsQuotedRejoin( test )
 
   test.case = 'empty splits';
 
-  var delimeter = [ '<', '>' ];
   var splits = [];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'default quotingPrefixes, quotingPostfixes; no delimeter';
+
+  var splits = [ `"`, `r1`, `"`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `"r1"`, `"r2"` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'quoting : 0';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 0,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'only prefixes and postfixes in splits';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `>`, `<`, `>` ];
   _.strSplitsQuotedRejoin
   ({
     splits,
@@ -9663,7 +9714,7 @@ function strSplitsQuotedRejoin( test )
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  var expected = [];
+  var expected = [ `<><>` ];
   test.identical( splits, expected );
 
   /* */
@@ -9961,6 +10012,8 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
   });
   var expected = [];
   test.identical( splits, expected );
+
+  /* */
 
   test.case = 'basic, add strings';
 

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9857,6 +9857,46 @@ function strSplitsQuotedRejoin( test )
   var expected = [ `<` ];
   test.identical( splits, expected );
 
+  /* */
+
+  test.case = '3 elems in splits';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>`, `<`, `r3`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1>`, `<r2>`, `<r3>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = '3 elems in splits, wrong enclosing';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `<`, `r2`, `>`, `<`, `r3` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1<r2>`, `<`, `r3` ];
+  test.identical( splits, expected );
+
+  /* - */
+
   if( !Config.debug )
   return;
 

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9935,7 +9935,7 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
-  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, first el withot quoting';
+  test.case = 'basic, o.pairing : 1, prefix and postfix are the same, first el withot quoting';
   var splits = [ `r1`, `"`, `r2`, `"` ];
   _.strSplitsQuotedRejoin
   ({
@@ -9948,6 +9948,23 @@ function strSplitsQuotedRejoin( test )
     inliningQuoting : 0,
   });
   var expected = [ 'r1', '"r2"' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix and postfix are the same, last el withot quoting';
+  var splits = [ `"`, `r1`, `"`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '"' ],
+    quotingPostfixes : [ '"' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '"r1"', 'r2' ];
   test.identical( splits, expected );
 
   /* */

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9666,6 +9666,63 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
+  test.case = 'splits : prefix and postfix';
+
+  var splits = [ '<', '>' ];
+  var delimeter = [ '<', '>' ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '<', '>' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'splits : prefix and prefix';
+
+  var splits = [ '<', '<' ];
+  var delimeter = [ '<', '>' ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '<', '<' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'splits : postfix and postfix';
+
+  var splits = [ '>', '>' ];
+  var delimeter = [ '<', '>' ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '>', '>' ];
+  test.identical( splits, expected );
+
+  /* */
+
   test.case = 'default quotingPrefixes, quotingPostfixes';
 
   var splits = [ `"`, `r1`, `"`, `"`, `r2`, `"` ];

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9739,7 +9739,6 @@ function strSplitsQuotedRejoin( test )
   /* */
 
   test.case = 'quoting : 0';
-
   var delimeter = [ '<', '>' ];
   var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
   _.strSplitsQuotedRejoin
@@ -9815,6 +9814,38 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
+  test.case = 'basic, first el withot quoting';
+  var splits = [ `r1`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ 'r1', '<r2>' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, last el withot quoting';
+  var splits = [ `<`, `r1`, `>`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '<r1>', 'r2' ];
+  test.identical( splits, expected );
+
+  /* */
+
   test.case = 'basic, o.pairing : 1, prefix and postfix are the same';
 
   var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
@@ -9836,7 +9867,7 @@ function strSplitsQuotedRejoin( test )
   test.case = 'basic, o.pairing : 1, prefix and postfix are NOT the same';
 
   var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
-  var result = _.strSplitsQuotedRejoin
+  _.strSplitsQuotedRejoin
   ({
     splits,
     quoting : 1,
@@ -9846,7 +9877,59 @@ function strSplitsQuotedRejoin( test )
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  test.identical( result, undefined );
+  var expected = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, prefix[ 1 ] and postfix[ 1 ] are NOT the same';
+  var splits = [ `"`, `r1`, `"`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '"', '<' ],
+    quotingPostfixes : [ '"', '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '"r1"', '<', 'r2', '>' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are NOT the same, prefix[ 1 ] and postfix[ 1 ] are the same';
+  var splits = [ `<`, `r1`, `>`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<', '"' ],
+    quotingPostfixes : [ '>', '"' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '<', 'r1', '>', '"r2"' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, first el withot quoting';
+  var splits = [ `r1`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '"' ],
+    quotingPostfixes : [ '"' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ 'r1', '"r2"' ];
+  test.identical( splits, expected );
 
   /* */
 

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9765,7 +9765,7 @@ function strSplitsQuotedRejoin( test )
   ({
     splits,
     quoting : 1,
-    quotingPrefixes : [ '<<', ],
+    quotingPrefixes : [ '<<' ],
     quotingPostfixes : [ '>>>' ],
     preservingQuoting : 1,
     inliningQuoting : 0,
@@ -9923,6 +9923,23 @@ function strSplitsQuotedRejoin( test )
     inliningQuoting : 0,
   });
   var expected = [ `>`, `r1`, `<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `quotingPrefixes : [ '{', '<' ], quotingPostfixes : [ '>', '}' ]`;
+
+  var splits = [ `{`, `r1`, `>`, `<`, `r2`, `}` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    quotingPrefixes : [ '{', '<' ],
+    quotingPostfixes : [ '>', '}' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `{r1>`, `<r2}` ];
   test.identical( splits, expected );
 
   /* */

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9840,7 +9840,7 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
-  test.case = 'prefix & postfix are different, only prefix in splits';
+  test.case = 'only prefix in splits';
 
   var delimeter = [ '<', '>' ];
   var splits = [ `<` ];
@@ -9878,6 +9878,228 @@ function strSplitsQuotedRejoin( test )
     _.strSplitsQuotedRejoin( 13 );
   });
 
+}
+
+//
+
+function strSplitsQuotedRejoinOptionOnQuoting( test )
+{
+  test.case = 'basic, add strings';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => '+' + el + '+'
+  });
+  var expected = [ `+<r1>+`, `+<r2>+` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, preservingQuoting : 0, add strings';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 0,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => '+' + el + '+'
+  });
+  var expected = [ `+r1+`, `+r2+` ];
+
+  /* */
+
+  test.case = 'prefix & postfix are the same, no transformation';
+
+  var delimeter = [ '-' ];
+  var splits = [ `-`, `r1`, `-`, `-`, `r2`, `-` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '-' ],
+    quotingPostfixes : [ '-' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => el
+  });
+  var expected = [ `-r1-`, `-r2-` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, 2 prefixes, return +';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => '+'
+  });
+  var expected = [ `+`, `+` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, 2 postfixes, return empty string';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => ''
+  });
+  var expected = [ ``, `>`, `` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, no matching postfix first, return [ o.quoting, o.delimeter ]';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => [ o.quoting, o.delimeter ]
+  });
+  var expected = [ [ 1, delimeter ] ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, no matching postfix last, return [ el, o.quoting ]';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => [ el, o.quoting ]
+  });
+  var expected = [ [ '<r1>', 1 ], '<', 'r2' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `prefix & postfix are different, no matching postfix first, with delimiter, return 'el : ' + el`;
+
+  var delimeter = [ '|' ];
+  var splits = [ `<`, `r1`, `|`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `el : <r1|<r2>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `prefix & postfix are different, no matching postfix last, with delimiter, return 'el : ' + el`;
+
+  var delimeter = [ '|' ];
+  var splits = [ `<`, `r1`, `>`, `|`, `<`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `el : <r1>`, `|<r2` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `prefix & postfix are different, postfix before prefix, return 'el : ' + el`;
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `>`, `r1`, `<` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `>`, `r1`, `<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `only prefix in splits, return 'el : ' + el`;
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `<` ];
+  test.identical( splits, expected );
 
 }
 
@@ -16928,7 +17150,7 @@ var Self =
     strSplitsDropEmpty,
     strSplitsUngroupedJoin,
     strSplitsQuotedRejoin, /* qqq xxx : extend, please */
-
+    strSplitsQuotedRejoinOptionOnQuoting,
     // splitter
 
     strSplitFast,

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9846,7 +9846,7 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
-  test.case = 'basic, o.pairing : 1, prefix and postfix are the same';
+  test.case = 'basic, o.pairing : 1, prefix and postfix are the same, complementary';
 
   var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
   _.strSplitsQuotedRejoin
@@ -9864,7 +9864,27 @@ function strSplitsQuotedRejoin( test )
 
   /* */
 
-  test.case = 'basic, o.pairing : 1, prefix and postfix are NOT the same';
+  test.case = 'basic, o.pairing : 1, prefix and postfix are NOT the same, not complementary';
+
+  var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
+  var delimeter = [ '<', '>' ]
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix and postfix are NOT the same, complementary';
 
   var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
   _.strSplitsQuotedRejoin
@@ -9877,12 +9897,12 @@ function strSplitsQuotedRejoin( test )
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  var expected = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  var expected = [ `<r1>`, `<r2>` ];
   test.identical( splits, expected );
 
   /* */
 
-  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, prefix[ 1 ] and postfix[ 1 ] are NOT the same';
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, prefix[ 1 ] and postfix[ 1 ] are NOT the same, complementary';
   var splits = [ `"`, `r1`, `"`, `<`, `r2`, `>` ];
   _.strSplitsQuotedRejoin
   ({
@@ -9894,12 +9914,12 @@ function strSplitsQuotedRejoin( test )
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  var expected = [ '"r1"', '<', 'r2', '>' ];
+  var expected = [ '"r1"', '<r2>' ];
   test.identical( splits, expected );
 
   /* */
 
-  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are NOT the same, prefix[ 1 ] and postfix[ 1 ] are the same';
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are NOT the same, prefix[ 1 ] and postfix[ 1 ] are the same, complementary';
   var splits = [ `<`, `r1`, `>`, `"`, `r2`, `"` ];
   _.strSplitsQuotedRejoin
   ({
@@ -9911,7 +9931,7 @@ function strSplitsQuotedRejoin( test )
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  var expected = [ '<', 'r1', '>', '"r2"' ];
+  var expected = [ '<r1>', '"r2"' ];
   test.identical( splits, expected );
 
   /* */
@@ -9930,7 +9950,26 @@ function strSplitsQuotedRejoin( test )
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  var expected = [ '<', 'r1', '>', '"', 'r2', '"' ];
+  var expected = [ '<r1>"', 'r2', '"' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'basic, o.pairing : 1, prefix[ 0 ], postfix[ 0 ] - complementary, prefix[ 1 ], postfix[ 1 ] - not complementary';
+  var delimeter = [ '<', '"', '{', '>' ];
+  var splits = [ `<`, `r1`, `"`, `{`, `r2`, `}` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<', '{' ],
+    quotingPostfixes : [ '"', '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ '<r1"', `{`, `r2`, `}` ];
   test.identical( splits, expected );
 
   /* */
@@ -10493,7 +10532,7 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
 
   /* */
 
-  test.case = `basic, o.pairing : 1, prefix and postfix are the same, return 'el : ' + el`;
+  test.case = `basic, o.pairing : 1, prefix and postfix are the same, complementary, return 'el : ' + el`;
 
   var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
   _.strSplitsQuotedRejoin
@@ -10512,7 +10551,28 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
 
   /* */
 
-  test.case = `basic, o.pairing : 1, prefix and postfix are NOT the same, return 'el : ' + el`;
+  test.case = `basic, o.pairing : 1, prefix and postfix are NOT the same, not complementary, return 'el : ' + el`;
+
+  var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
+  var delimeter = [ '<', '>' ]
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix and postfix are NOT the same, complementary, return 'el : ' + el`;
 
   var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
   _.strSplitsQuotedRejoin
@@ -10526,12 +10586,12 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
     inliningQuoting : 0,
     onQuoting : ( el, o ) => 'el : ' + el
   });
-  var expected = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  var expected = [ `el : <r1>`, `el : <r2>` ];
   test.identical( splits, expected );
 
   /* */
 
-  test.case = `basic, o.pairing : 1, prefix[ 1 ] and postfix[ 1 ] are NOT the same, return 'el : ' + el`;
+  test.case = `basic, o.pairing : 1, prefix[ 1 ] and postfix[ 1 ] are NOT the same, complementary, return 'el : ' + el`;
   var splits = [ `"`, `r1`, `"`, `<`, `r2`, `>` ];
   _.strSplitsQuotedRejoin
   ({
@@ -10544,12 +10604,12 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
     inliningQuoting : 0,
     onQuoting : ( el, o ) => 'el : ' + el
   });
-  var expected = [ 'el : "r1"', '<', 'r2', '>' ];
+  var expected = [ 'el : "r1"', 'el : <r2>' ];
   test.identical( splits, expected );
 
   /* */
 
-  test.case = `basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are NOT the same, return 'el : ' + el`;
+  test.case = `basic, o.pairing : 1, prefix[ 1 ] and postfix[ 1 ] are the same, complementary, return 'el : ' + el`;
   var splits = [ `<`, `r1`, `>`, `"`, `r2`, `"` ];
   _.strSplitsQuotedRejoin
   ({
@@ -10562,12 +10622,52 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
     inliningQuoting : 0,
     onQuoting : ( el, o ) => 'el : ' + el
   });
-  var expected = [ '<', 'r1', '>', 'el : "r2"' ];
+  var expected = [ 'el : <r1>', 'el : "r2"' ];
   test.identical( splits, expected );
 
   /* */
 
-  test.case = `basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, first el withot quoting, return 'el : ' + el`;
+  test.case = `basic, o.pairing : 1, prefix[ 0 ] = postfix[ 1 ] prefix[ 1 ] = postfix[ 0 ], return 'el : ' + el`;
+  var delimeter = [ '<', '"' ];
+  var splits = [ `<`, `r1`, `>`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<', '"' ],
+    quotingPostfixes : [ '"', '<' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ 'el : <r1>"', 'r2', '"' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix[ 0 ], postfix[ 0 ] - complementary, prefix[ 1 ], postfix[ 1 ] - not complementary, return 'el : ' + el`;
+  var delimeter = [ '<', '"', '{', '>' ];
+  var splits = [ `<`, `r1`, `"`, `{`, `r2`, `}` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<', '{' ],
+    quotingPostfixes : [ '"', '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ 'el : <r1"', `{`, `r2`, `}` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix and postfix are the same, first el withot quoting, return 'el : ' + el`;
   var splits = [ `r1`, `"`, `r2`, `"` ];
   _.strSplitsQuotedRejoin
   ({
@@ -10581,6 +10681,24 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
     onQuoting : ( el, o ) => 'el : ' + el
   });
   var expected = [ 'r1', 'el : "r2"' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix and postfix are the same, last el withot quoting, return 'el : ' + el`;
+  var splits = [ `"`, `r1`, `"`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '"' ],
+    quotingPostfixes : [ '"' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ 'el : "r1"', 'r2' ];
   test.identical( splits, expected );
 
 }

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -17363,7 +17363,7 @@ var Self =
     strSplitsCoupledGroup,
     strSplitsDropEmpty,
     strSplitsUngroupedJoin,
-    strSplitsQuotedRejoin, /* qqq xxx : extend, please */
+    strSplitsQuotedRejoin, /* qqq xxx : extend, please | aaa : Done. Yevhen S. */
     strSplitsQuotedRejoinOptionOnQuoting,
     // splitter
 

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -10455,6 +10455,98 @@ function strSplitsQuotedRejoinOptionOnQuoting( test )
   var expected = [ `<` ];
   test.identical( splits, expected );
 
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix and postfix are the same, return 'el : ' + el`;
+
+  var splits = [ `<`, `r1`, `<`, `<`, `r2`, `<` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '<' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `el : <r1<`, `el : <r2<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix and postfix are NOT the same, return 'el : ' + el`;
+
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix[ 1 ] and postfix[ 1 ] are NOT the same, return 'el : ' + el`;
+  var splits = [ `"`, `r1`, `"`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '"', '<' ],
+    quotingPostfixes : [ '"', '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ 'el : "r1"', '<', 'r2', '>' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are NOT the same, return 'el : ' + el`;
+  var splits = [ `<`, `r1`, `>`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '<', '"' ],
+    quotingPostfixes : [ '>', '"' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ '<', 'r1', '>', 'el : "r2"' ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = `basic, o.pairing : 1, prefix[ 0 ] and postfix[ 0 ] are the same, first el withot quoting, return 'el : ' + el`;
+  var splits = [ `r1`, `"`, `r2`, `"` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    quoting : 1,
+    pairing : 1,
+    quotingPrefixes : [ '"' ],
+    quotingPostfixes : [ '"' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+    onQuoting : ( el, o ) => 'el : ' + el
+  });
+  var expected = [ 'r1', 'el : "r2"' ];
+  test.identical( splits, expected );
+
 }
 
 // --

--- a/proto/wtools/abase/l0.test/Str.test.s
+++ b/proto/wtools/abase/l0.test/Str.test.s
@@ -9668,24 +9668,216 @@ function strSplitsQuotedRejoin( test )
   var expected = [ `<r1>`, `<r2>` ];
   test.identical( splits, expected );
 
-  test.case = 'basic2';
+  /* */
 
-  var delimeter = [ '-', '+' ];
-  var splits = [ `-`, `r1`, `+`, `-`, `r2`, `+` ];
-  debugger;
+  test.case = 'basic, preservingQuoting : 0';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 0,
+    inliningQuoting : 0,
+  });
+  var expected = [ `r1`, `r2` ];
+
+  /* */
+
+  test.case = 'prefix & postfix are the same';
+
+  var delimeter = [ '-' ];
+  var splits = [ `-`, `r1`, `-`, `-`, `r2`, `-` ];
   _.strSplitsQuotedRejoin
   ({
     splits,
     delimeter,
     quoting : 1,
     quotingPrefixes : [ '-' ],
-    quotingPostfixes : [ '+' ],
+    quotingPostfixes : [ '-' ],
     preservingQuoting : 1,
     inliningQuoting : 0,
   });
-  debugger;
-  var expected = [ `-r1+`, `-r2+` ];
+  var expected = [ `-r1-`, `-r2-` ];
   test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, 2 prefixes';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `<`, `r1`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<<r1>`, `<r2>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, 2 postfixes';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `>`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1>`, `>`, `<r2>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, no matching postfix first';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1<r2>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, no matching postfix last';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<`, `r1`, `>`, `<`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1>`, `<`, `r2` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, no matching postfix first, with delimiter';
+
+  var delimeter = [ '|' ];
+  var splits = [ `<`, `r1`, `|`, `<`, `r2`, `>` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1|<r2>` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, no matching postfix last, with delimiter';
+
+  var delimeter = [ '|' ];
+  var splits = [ `<`, `r1`, `>`, `|`, `<`, `r2` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<r1>`, `|<r2` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, postfix before prefix';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `>`, `r1`, `<` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `>`, `r1`, `<` ];
+  test.identical( splits, expected );
+
+  /* */
+
+  test.case = 'prefix & postfix are different, only prefix in splits';
+
+  var delimeter = [ '<', '>' ];
+  var splits = [ `<` ];
+  _.strSplitsQuotedRejoin
+  ({
+    splits,
+    delimeter,
+    quoting : 1,
+    quotingPrefixes : [ '<' ],
+    quotingPostfixes : [ '>' ],
+    preservingQuoting : 1,
+    inliningQuoting : 0,
+  });
+  var expected = [ `<` ];
+  test.identical( splits, expected );
+
+  if( !Config.debug )
+  return;
+
+  test.case = 'no arguments';
+  test.shouldThrowErrorSync( function()
+  {
+    _.strSplitsQuotedRejoin();
+  });
+
+  test.case = 'argument is wrong';
+  test.shouldThrowErrorSync( function()
+  {
+    _.strSplitsQuotedRejoin([]);
+  });
+
+  test.case = 'argument is wrong';
+  test.shouldThrowErrorSync( function()
+  {
+    _.strSplitsQuotedRejoin( 13 );
+  });
+
 
 }
 

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1933,7 +1933,7 @@ strSplitsQuotedRejoin_body.defaults =
   inliningQuoting : 1,
   splits : null,
   delimeter : null,
-  onQuoting : null, /* qqq : cover */
+  onQuoting : null, /* qqq : cover | aaa : Done. Yevhen S. */
   pairing : 0
 }
 

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1824,8 +1824,6 @@ function strSplitsQuotedRejoin_head( routine, args )
     }
     else _.assert( 0, 'unexpected type of {-o.quoting-}' );
 
-    _.assert( _.boolLike( o.pairing ), 'option::o.pairing must be BoolLike' );
-
     _.assert
     (
       !o.pairing || o.quotingPrefixes.length === o.quotingPostfixes.length,

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1904,6 +1904,11 @@ function strSplitsQuotedRejoin_body( o )
       {
         let splitNew = o.splits.splice( s, 2 ).join( '' );
         o.splits[ s-1 ] = o.splits[ s-1 ] + splitNew;
+        // let splitNew = o.splits.splice( s, 2 ).join( '' );
+        // if( o.onQuoting )
+        // o.splits[ s-1 ] = o.onQuoting( splitNew, o );
+        // else
+        // o.splits[ s-1 ] = o.splits[ s-1 ] + splitNew;
       }
       else
       {

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1851,10 +1851,6 @@ function strSplitsQuotedRejoin_body( o )
   _.assert( arguments.length === 1 );
   _.assert( _.arrayIs( o.splits ) );
 
-  // if( o.pairing )
-  // if( !_.longIdentical( o.quotingPrefixes, o.quotingPostfixes ) )
-  // return undefined;
-
   /* quoting */
 
   // let s = 1; // why was it 1??

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1904,11 +1904,6 @@ function strSplitsQuotedRejoin_body( o )
       {
         let splitNew = o.splits.splice( s, 2 ).join( '' );
         o.splits[ s-1 ] = o.splits[ s-1 ] + splitNew;
-        // let splitNew = o.splits.splice( s, 2 ).join( '' );
-        // if( o.onQuoting )
-        // o.splits[ s-1 ] = o.onQuoting( splitNew, o );
-        // else
-        // o.splits[ s-1 ] = o.splits[ s-1 ] + splitNew;
       }
       else
       {

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1877,7 +1877,7 @@ function strSplitsQuotedRejoin_body( o )
         if( split2 === postfix )
         {
           if( o.pairing )
-          if( o.splits[ s ] !== o.splits[ s2 ] )
+          if( o.quotingPrefixes.indexOf( o.splits[ s ] ) !== o.quotingPostfixes.indexOf( o.splits[ s2 ] ) )
           break;
           let bextra = 0;
           let eextra = 0;

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1851,9 +1851,9 @@ function strSplitsQuotedRejoin_body( o )
   _.assert( arguments.length === 1 );
   _.assert( _.arrayIs( o.splits ) );
 
-  if( o.pairing )
-  if( !_.longIdentical( o.quotingPrefixes, o.quotingPostfixes ) )
-  return undefined;
+  // if( o.pairing )
+  // if( !_.longIdentical( o.quotingPrefixes, o.quotingPostfixes ) )
+  // return undefined;
 
   /* quoting */
 
@@ -1880,6 +1880,9 @@ function strSplitsQuotedRejoin_body( o )
         let split2 = o.splits[ s2 ];
         if( split2 === postfix )
         {
+          if( o.pairing )
+          if( o.splits[ s ] !== o.splits[ s2 ] )
+          break;
           let bextra = 0;
           let eextra = 0;
           if( o.inliningQuoting )

--- a/proto/wtools/abase/l0/l5/fStr.s
+++ b/proto/wtools/abase/l0/l5/fStr.s
@@ -1824,6 +1824,14 @@ function strSplitsQuotedRejoin_head( routine, args )
     }
     else _.assert( 0, 'unexpected type of {-o.quoting-}' );
 
+    _.assert( _.boolLike( o.pairing ), 'option::o.pairing must be BoolLike' );
+
+    _.assert
+    (
+      !o.pairing || o.quotingPrefixes.length === o.quotingPostfixes.length,
+      `If option::o.paring is true then the length of o.quotingPrefixes should be equal to the length of o.quotingPostfixes`
+    );
+
     if( Config.debug )
     {
       _.assert( o.quotingPrefixes.length === o.quotingPostfixes.length );
@@ -1844,6 +1852,10 @@ function strSplitsQuotedRejoin_body( o )
 
   _.assert( arguments.length === 1 );
   _.assert( _.arrayIs( o.splits ) );
+
+  if( o.pairing )
+  if( !_.longIdentical( o.quotingPrefixes, o.quotingPostfixes ) )
+  return undefined;
 
   /* quoting */
 
@@ -1922,6 +1934,7 @@ strSplitsQuotedRejoin_body.defaults =
   splits : null,
   delimeter : null,
   onQuoting : null, /* qqq : cover */
+  pairing : 0
 }
 
 //


### PR DESCRIPTION
1. Extend test routine `strSplitsQuotedRejoin `.
    strSplitsQuotedRejoin, /* qqq xxx : extend, please */
2. Wrote test routine `strSplitsQuotedRejoinOptionOnQuoting`.
    onQuoting : null, /* qqq : cover */
3. Implement option::o.pairing