### PR TITLE
READY UNSTABLE : Dt hp missing generic

### DIFF
--- a/rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs
+++ b/rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs
@@ -1,0 +1,9 @@
+use type_constructor::prelude::*;
+
+
+fn main()
+{
+
+  types!( pair Bad : Option );
+
+}

--- a/rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.stderr
+++ b/rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.stderr
@@ -1,0 +1,491 @@
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         pub $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         pub $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > ; 2
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > : Clone,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > ; 2
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > : Clone,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > : Clone,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > : Clone,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > : Clone,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > : Clone,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > ; 2
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > ; 2
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > ; 2
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           fn make_1( _0 : $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? > ) -> Self
+  |                                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             _0 : $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                        +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs:7:22
+  |
+7 |   types!( pair Bad : Option );
+  |                      ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             _1 : $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
+  |                                                        +

--- a/rust/test/dt/type_constructor/single/single_self_containing_test.rs
+++ b/rust/test/dt/type_constructor/single/single_self_containing_test.rs
@@ -1,0 +1,13 @@
+use type_constructor::prelude::*;
+
+
+fn main()
+{
+  types!
+  {
+
+    // struct Bad( Box< Bad > ); compiles without errors
+    single Bad : Box< Bad >;
+
+  }
+}

--- a/rust/test/dt/type_constructor/single/single_self_containing_test.stderr
+++ b/rust/test/dt/type_constructor/single/single_self_containing_test.stderr
@@ -1,0 +1,299 @@
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0109]: type arguments are not allowed on type parameter `Bad`
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:6:3
+   |
+6  | /   types!
+7  | |   {
+8  | |
+9  | |     // struct Bad( Box< Bad > ); compiles without errors
+10 | |     single Bad : Box< Bad >;
+   | |            --- not allowed on type parameter `Bad`
+11 | |
+12 | |   }
+   | |___^ type argument not allowed
+   |
+note: type parameter `Bad` defined here
+  --> ../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs:10:23
+   |
+10 |     single Bad : Box< Bad >;
+   |                       ^^^
+   = note: this error originates in the macro `$crate::_single` which comes from the expansion of the macro `types` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/rust/test/dt/type_constructor/type_constructor_tests.rs
+++ b/rust/test/dt/type_constructor/type_constructor_tests.rs
@@ -30,4 +30,6 @@ fn trybuild_tests()
 
   #[ cfg( any( not( any( feature = "use_std", feature = "use_alloc" ) ), not( feature = "many" ) ) ) ]
   t.compile_fail( "../../../rust/test/dt/type_constructor/dynamic/types_many_no/*.rs" );
+
+  t.compile_fail( "../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs" );
 }

--- a/rust/test/dt/type_constructor/type_constructor_tests.rs
+++ b/rust/test/dt/type_constructor/type_constructor_tests.rs
@@ -32,4 +32,6 @@ fn trybuild_tests()
   t.compile_fail( "../../../rust/test/dt/type_constructor/dynamic/types_many_no/*.rs" );
 
   t.compile_fail( "../../../rust/test/dt/type_constructor/single/single_self_containing_test.rs" );
+
+  t.compile_fail( "../../../rust/test/dt/type_constructor/pair/homo_pair_missing_generic_test.rs" );
 }


### PR DESCRIPTION
Macros shows incorrect error message.

It must be hidden:
```
help: add missing generic argument
 --> rust/impl/dt/type_constructor/pair.rs
  |
  |         pub $TypeSplit1x1 $( :: $TypeSplit1xN )* <T $( $( $( $ParamName1 ),+ )? )? >,
  |   
```