### PR TITLE
READY UNSTABLE : Test pair missing generic shows macros implementation

### DIFF
--- a/rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs
+++ b/rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs
@@ -1,0 +1,12 @@
+use type_constructor::prelude::*;
+
+
+fn main()
+{
+  types!
+  {
+
+    pair Bad : Option< T >, Option;
+
+  }
+}

--- a/rust/test/dt/type_constructor/pair/pair_missing_generic_test.stderr
+++ b/rust/test/dt/type_constructor/pair/pair_missing_generic_test.stderr
@@ -1,0 +1,71 @@
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs:9:29
+  |
+9 |     pair Bad : Option< T >, Option;
+  |                             ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         pub $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs:9:29
+  |
+9 |     pair Bad : Option< T >, Option;
+  |                             ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs:9:29
+  |
+9 |     pair Bad : Option< T >, Option;
+  |                             ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |         $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
+  |                                               +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs:9:29
+  |
+9 |     pair Bad : Option< T >, Option;
+  |                             ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |           $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
+  |                                                 +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs:9:29
+  |
+9 |     pair Bad : Option< T >, Option;
+  |                             ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
+  |                                                   +
+
+error[E0107]: this enum takes 1 generic argument but 0 generic arguments were supplied
+ --> ../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs:9:29
+  |
+9 |     pair Bad : Option< T >, Option;
+  |                             ^^^^^^ expected 1 generic argument
+  |
+help: add missing generic argument
+ --> rust/impl/dt/type_constructor/pair.rs
+  |
+  |             _1 : $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
+  |                                                        +

--- a/rust/test/dt/type_constructor/type_constructor_tests.rs
+++ b/rust/test/dt/type_constructor/type_constructor_tests.rs
@@ -30,4 +30,6 @@ fn trybuild_tests()
 
   #[ cfg( any( not( any( feature = "use_std", feature = "use_alloc" ) ), not( feature = "many" ) ) ) ]
   t.compile_fail( "../../../rust/test/dt/type_constructor/dynamic/types_many_no/*.rs" );
+
+  t.compile_fail( "../../../rust/test/dt/type_constructor/pair/pair_missing_generic_test.rs" );
 }


### PR DESCRIPTION
Macros shows incorrect error message.

It must be hidden:
```
help: add missing generic argument
 --> rust/impl/dt/type_constructor/pair.rs
  |
  |         pub $TypeSplit2x1 $( :: $TypeSplit2xN )* <T $( $( $ParamName2 ),* )? >,
  |                                                   +
```