### PR TITLE
READY : Fix samples

### DIFF
--- a/rust/impl/dt/type_constructor/pair.rs
+++ b/rust/impl/dt/type_constructor/pair.rs
@@ -167,7 +167,7 @@ pub( crate ) mod private
     /// ```
     /// let i32_and_f32_in_tuple = type_constructor::Pair::< i32, f32 >::from( ( 13, 13.0 ) );
     /// dbg!( i32_and_f32_in_tuple );
-    /// // let vec_of_i32_in_tuple = type_constructor::Pair::< i32, i32 >::from( [ 13, 13 ] );
+    /// // let vec_of_i32_in_tuple = type_constructor::Pair::< i32, f32 >::from( [ 13, 13.0 ] );
     /// ```
     ///
 

--- a/rust/impl/dt/type_constructor/pair.rs
+++ b/rust/impl/dt/type_constructor/pair.rs
@@ -167,7 +167,7 @@ pub( crate ) mod private
     /// ```
     /// let i32_and_f32_in_tuple = type_constructor::Pair::< i32, f32 >::from( ( 13, 13.0 ) );
     /// dbg!( i32_and_f32_in_tuple );
-    /// vec_of_i32_in_tuple = Pair( 13, 13.0 )
+    /// // let vec_of_i32_in_tuple = type_constructor::Pair::< i32, i32 >::from( [ 13, 13 ] );
     /// ```
     ///
 
@@ -181,7 +181,7 @@ pub( crate ) mod private
     /// ```
     /// let two_i32_in_tuple = type_constructor::HomoPair::< i32 >::from( ( 13, 31 ) );
     /// dbg!( two_i32_in_tuple );
-    /// vec_of_i32_in_tuple = HomoPair( 13, 31 )
+    /// let vec_of_i32_in_tuple = type_constructor::HomoPair::< i32 >::from( [ 13, 31 ] );
     /// ```
     ///
 


### PR DESCRIPTION
Before, this examples was commented( both )
For type Homopair can be used from array and sample show this
For Pair it can be used too, but it needs to set both generics to one type