### PR TITLE
READY: replace `matklad.rust-analyzer` with `rust-lang.rust-analyzer`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,7 @@ tasks :
 
 vscode :
   extensions :
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer
 
 github :
   prebuilds :


### PR DESCRIPTION
Small PR to update the rust-analyzer extension to it's new owner in the associated devcontainer.

