### PR TITLE
READY : Re-export Result and BasicError

### DIFF
--- a/rust/impl/ca/wca_lib.rs
+++ b/rust/impl/ca/wca_lib.rs
@@ -21,6 +21,10 @@ pub mod string
   pub use wtools::string::*;
 }
 
+/// Errors.
+#[ cfg( feature = "use_std" ) ]
+pub use wtools::{ Result, BasicError, err };
+
 use wtools::meta::mod_interface;
 
 crate::mod_interface!


### PR DESCRIPTION
It is needed for writing Routines.

Routine functions declaration:
```rs
  type RoutineWithoutContextFn = dyn Fn(( Args, Props )) -> Result< (), BasicError >;
  type RoutineWithContextFn = dyn Fn( ( Args, Props ), Context ) -> Result< (), BasicError >;
```