### PR TITLE
READY : WCA : dot command

### DIFF
--- a/rust/impl/ca/ca/commands_aggregator/aggregator.rs
+++ b/rust/impl/ca/ca/commands_aggregator/aggregator.rs
@@ -9,7 +9,7 @@ pub( crate ) mod private
 
     Command,
     Routine,
-    commands_aggregator::help::{ HelpGeneratorFn, HelpVariants },
+    commands_aggregator::help::{ HelpGeneratorFn, HelpVariants, dot_command },
   };
 
   use wtools::{ HashMap, Result, HashSet };
@@ -80,6 +80,8 @@ pub( crate ) mod private
           help.generate( &ca.help_generator, &mut ca.grammar_converter, &mut ca.executor_converter );
         }
       }
+
+      dot_command( &mut ca.grammar_converter, &mut ca.executor_converter );
 
       ca
     }

--- a/rust/impl/ca/ca/commands_aggregator/help.rs
+++ b/rust/impl/ca/ca/commands_aggregator/help.rs
@@ -8,7 +8,7 @@ pub( crate ) mod private
     Routine, Type
   };
   
-  use wtools::Itertools;
+  use wtools::{ Itertools, err };
 
   use std::rc::Rc;
 
@@ -49,7 +49,7 @@ pub( crate ) mod private
 
             if ac.is_empty()
             {
-              eprintln!( "Have no commands that starts with `{prefix}{command}`" );
+              return Err( err!( "Have no commands that starts with `{prefix}{command}`" ) );
             }
             else
             {

--- a/rust/impl/ca/ca/grammar/types.rs
+++ b/rust/impl/ca/ca/grammar/types.rs
@@ -67,7 +67,7 @@ pub( crate ) mod private
       i32 => | value | value as i32,
       i64 => | value | value as i64,
       f32 => | value | value as f32,
-      f64 => | value | value as f64;
+      f64 => | value | value;
     Value::String =>
       String => String::from,
       &'static str => | value : String | Box::leak( value.into_boxed_str() );
@@ -100,7 +100,6 @@ pub( crate ) mod private
         {
           let values = value
           .split( *delimeter )
-          .into_iter()
           .map( | val | kind.try_cast( val.into() ) )
           .collect::< Result< Vec< Value > > >()?;
           Ok( Value::List( values ) )

--- a/rust/impl/ca/ca/parser/command.rs
+++ b/rust/impl/ca/ca/parser/command.rs
@@ -6,7 +6,7 @@ pub( crate ) mod private
     RawCommand as Command,
     parser::parser::any_word,
   };
-  use wtools::{ Result, err };
+use wtools::{ HashMap, Result, err };
   use nom::
   {
     branch::alt,
@@ -62,14 +62,26 @@ pub( crate ) mod private
               }
             }),
             // it is the end
-            map( eof, | _ | Command::default() )
+            map
+            (
+              eof,
+              | _ |
+              Command
+              {
+                properties : HashMap::from_iter([ ( "command_prefix".to_string(), command_prefix.to_string() )]), ..Default::default()
+              }
+            )
           )),
         )),
         |( _, _, command )|
         {
           if command.name.ends_with( command_prefix )
           {
-            doted_command( command )
+            Command {
+              name : "".to_string(),
+              subjects : vec![ command.name ],
+              properties : HashMap::from_iter([ ( "command_prefix".to_string(), command_prefix.to_string() )]),
+            }
           }
           else
           {
@@ -77,27 +89,6 @@ pub( crate ) mod private
           }
         }
       )( input ) )
-    }
-  }
-
-  fn doted_command( raw_command : Command ) -> Command
-  {
-    // Perhaps that would be a good idea:
-    // if !raw_command.subjects.is_empty() || !raw_command.properties.is_empty()
-    // {
-    //   return Err( err!( "`{}` can not take arguments.", raw_command.name ) )
-    // }
-    let command_phrase = {
-      let mut tmp = raw_command.name;
-      tmp.pop();
-
-      tmp
-    };
-
-    Command {
-      name : "".to_string(),
-      subjects : vec![ command_phrase ],
-      properties : Default::default(),
     }
   }
 

--- a/rust/impl/ca/ca/parser/entities.rs
+++ b/rust/impl/ca/ca/parser/entities.rs
@@ -19,7 +19,7 @@ pub( crate ) mod private
   }
 
   /// Command representation
-  #[ derive( Debug, Clone, PartialEq, Eq ) ]
+  #[ derive( Debug, Default, Clone, PartialEq, Eq ) ]
   pub struct RawCommand
   {
     /// name of command without delimeter

--- a/rust/test/ca/inc/commands_aggregator/basic.rs
+++ b/rust/test/ca/inc/commands_aggregator/basic.rs
@@ -155,7 +155,7 @@ tests_impls!
     a_id!( Ok( () ), ca.perform( "." ) );
     a_id!( Ok( () ), ca.perform( ".cmd." ) );
 
-    a_id!( Ok( () ), ca.perform( ".c." ) );
+    a_true!( ca.perform( ".c." ).is_err() );
   }
 }
 

--- a/rust/test/ca/inc/commands_aggregator/basic.rs
+++ b/rust/test/ca/inc/commands_aggregator/basic.rs
@@ -128,6 +128,35 @@ tests_impls!
 
     a_id!( Ok( () ), ca.perform( "-command" ) );
   }
+
+  fn dot_command()
+  {
+    let ca = CommandsAggregator::former()
+    .grammar(
+    [
+      wca::Command::former()
+      .hint( "hint" )
+      .long_hint( "long_hint" )
+      .phrase( "cmd.first" )
+      .form(),
+      wca::Command::former()
+      .hint( "hint" )
+      .long_hint( "long_hint" )
+      .phrase( "cmd.second" )
+      .form(),
+    ])
+    .executor(
+    [
+      ( "cmd.first".to_owned(), Routine::new( | _ | { println!( "Command" ); Ok( () ) } ) ),
+      ( "cmd.second".to_owned(), Routine::new( | _ | { println!( "Command2" ); Ok( () ) } ) ),
+    ])
+    .build();
+
+    a_id!( Ok( () ), ca.perform( "." ) );
+    a_id!( Ok( () ), ca.perform( ".cmd." ) );
+
+    a_id!( Ok( () ), ca.perform( ".c." ) );
+  }
 }
 
 //
@@ -138,4 +167,5 @@ tests_index!
   with_only_general_help,
   custom_converters,
   custom_parser,
+  dot_command,
 }

--- a/rust/test/ca/inc/parser/command.rs
+++ b/rust/test/ca/inc/parser/command.rs
@@ -350,7 +350,7 @@ tests_impls!
       {
         name : "".into(),
         subjects : vec![],
-        properties : HashMap::new(),
+        properties : HashMap::from_iter([( "command_prefix".into(), ".".into() )]),
       }),
       parser.command( "." )
     );
@@ -361,8 +361,8 @@ tests_impls!
       Ok( RawCommand
       {
         name : "".into(),
-        subjects : vec![ "command".into() ],
-        properties : HashMap::new(),
+        subjects : vec![ "command.".into() ],
+        properties : HashMap::from_iter([( "command_prefix".into(), ".".into() )]),
       }),
       parser.command( ".command." )
     );
@@ -373,8 +373,8 @@ tests_impls!
       Ok( RawCommand
       {
         name : "".into(),
-        subjects : vec![ "command".into() ],
-        properties : HashMap::new(),
+        subjects : vec![ "command.".into() ],
+        properties : HashMap::from_iter([( "command_prefix".into(), ".".into() )]),
       }),
       parser.command( ".command. <this will be ignored>" )
     );

--- a/rust/test/ca/inc/parser/command.rs
+++ b/rust/test/ca/inc/parser/command.rs
@@ -338,6 +338,47 @@ tests_impls!
       parser.command( r#".command '\' queted \' \\ value' prop:"some \"quetes\" ' \\ in string""# )
     );
   }
+
+  fn dot_command()
+  {
+    let parser = Parser::former().form();
+
+    // single dot
+    a_id!
+    (
+      Ok( RawCommand
+      {
+        name : "".into(),
+        subjects : vec![],
+        properties : HashMap::new(),
+      }),
+      parser.command( "." )
+    );
+
+    // command .
+    a_id!
+    (
+      Ok( RawCommand
+      {
+        name : "".into(),
+        subjects : vec![ "command".into() ],
+        properties : HashMap::new(),
+      }),
+      parser.command( ".command." )
+    );
+
+    // command . with subjects
+    a_id!
+    (
+      Ok( RawCommand
+      {
+        name : "".into(),
+        subjects : vec![ "command".into() ],
+        properties : HashMap::new(),
+      }),
+      parser.command( ".command. <this will be ignored>" )
+    );
+  }
 }
 
 //
@@ -352,4 +393,5 @@ tests_index!
   path_in_property,
   list_in_property,
   string_value,
+  dot_command,
 }


### PR DESCRIPTION
- [X] `.` - prints all available commands
- [X] `.command.` - prints all available commands starts with `.command.`
- [x] `.comm.` - do not print `.command`
- [x] Printing correction. print commands with `.` at the beginning
- [x] Error if command doesn't exists