### PR TITLE
READY : GrammarConverter commands make public

### DIFF
--- a/rust/impl/ca/ca/grammar/converter.rs
+++ b/rust/impl/ca/ca/grammar/converter.rs
@@ -32,8 +32,10 @@ pub( crate ) mod private
   #[ derive( Former ) ]
   pub struct GrammarConverter
   {
+    /// all available commands
+    // TODO: Make getters
     #[ setter( false ) ]
-    pub( crate ) commands : HashMap< String, Vec< Command > >,
+    pub commands : HashMap< String, Vec< Command > >,
   }
 
   impl GrammarConverterFormer


### PR DESCRIPTION
Problem:
User can not implement own help command cuz list of commands is private