### PR TITLE
NOT READY : WCA: Make Grammar - static

### DIFF
--- a/module/move/wca/Cargo.toml
+++ b/module/move/wca/Cargo.toml
@@ -68,6 +68,7 @@ former = { version = "~0.1", path = "../../rust/former" } # zzz : remove. fix
 anymap = "0.12"
 log = "0.4"
 nom = "7.1"
+phf = { version = "0.11", features = [ "macros" ] }
 
 [dev-dependencies]
 test_tools = { version = "~0.1", path = "../../rust/test_tools" }

--- a/rust/impl/ca/ca/commands_aggregator/aggregator.rs
+++ b/rust/impl/ca/ca/commands_aggregator/aggregator.rs
@@ -27,19 +27,29 @@ pub( crate ) mod private
     help_generator : HelpGeneratorFn,
     #[ default( HashSet::from([ HelpVariants::All ]) ) ]
     help_variants : HashSet< HelpVariants >,
-    grammar_converter : GrammarConverter,
+    grammar_converter : crate::StaticGrammarConverter,
     executor_converter : ExecutorConverter,
   }
 
   impl CommandsAggregatorFormer
   {
-    pub fn grammar< V >( mut self, commands : V ) -> Self
-    where
-      V : Into< Vec< Command > >
+    // pub fn grammar< V >( mut self, commands : V ) -> Self
+    // where
+    //   V : Into< Vec< Command > >
+    // {
+    //   let grammar = GrammarConverter::former()
+    //   .commands( commands )
+    //   .form();
+
+    //   self.grammar_converter = Some( grammar );
+    //   self
+    // }
+    pub fn grammar( mut self, commands : &'static phf::Map< &'static str, &[ crate::StaticGrammarCommand ] > ) -> Self
     {
-      let grammar = GrammarConverter::former()
-      .commands( commands )
-      .form();
+      let grammar = crate::StaticGrammarConverter
+      {
+        commands
+      };
 
       self.grammar_converter = Some( grammar );
       self
@@ -69,17 +79,17 @@ pub( crate ) mod private
     {
       let mut ca = self.form();
 
-      if ca.help_variants.contains( &HelpVariants::All )
-      {
-        HelpVariants::All.generate( &ca.help_generator, &mut ca.grammar_converter, &mut ca.executor_converter );
-      }
-      else
-      {
-        for help in &ca.help_variants
-        {
-          help.generate( &ca.help_generator, &mut ca.grammar_converter, &mut ca.executor_converter );
-        }
-      }
+      // if ca.help_variants.contains( &HelpVariants::All )
+      // {
+      //   HelpVariants::All.generate( &ca.help_generator, &mut ca.grammar_converter, &mut ca.executor_converter );
+      // }
+      // else
+      // {
+      //   for help in &ca.help_variants
+      //   {
+      //     help.generate( &ca.help_generator, &mut ca.grammar_converter, &mut ca.executor_converter );
+      //   }
+      // }
 
       ca
     }

--- a/rust/impl/ca/ca/commands_aggregator/help.rs
+++ b/rust/impl/ca/ca/commands_aggregator/help.rs
@@ -217,11 +217,29 @@ pub( crate ) mod private
     }
   }
 
-  type HelpFucntionFn = Rc< dyn Fn( &GrammarConverter, Option< &Command > ) -> String >;
+  type HelpFunctionFn = Rc< dyn Fn( &GrammarConverter, Option< &Command > ) -> String >;
 
   /// Container for function that generates help string for any command
+  /// 
+  /// ```
+  /// # use wca::commands_aggregator::help::HelpGeneratorFn;
+  /// use wca::{ GrammarConverter, Command };
+  /// 
+  /// fn my_help_generator( grammar : &GrammarConverter, command : Option< &Command > ) -> String
+  /// {
+  ///   format!( "Help content based on grammar and command" )
+  /// }
+  /// 
+  /// let help_fn = HelpGeneratorFn::new( my_help_generator );
+  /// # let grammar = &GrammarConverter::former().form();
+  /// 
+  /// help_fn.exec( grammar, None );
+  /// // or
+  /// # let cmd = Command::former().form();
+  /// help_fn.exec( grammar, Some( &cmd ) );
+  /// ```
   #[ derive( Clone ) ]
-  pub struct HelpGeneratorFn( HelpFucntionFn );
+  pub struct HelpGeneratorFn( HelpFunctionFn );
 
   impl Default for HelpGeneratorFn
   {
@@ -233,7 +251,7 @@ pub( crate ) mod private
 
   impl HelpGeneratorFn
   {
-    /// Wrap a help fucntion
+    /// Wrap a help function
     pub fn new< HelpFunction >( func : HelpFunction ) -> Self
     where
       HelpFunction : Fn( &GrammarConverter, Option< &Command > ) -> String + 'static
@@ -244,7 +262,7 @@ pub( crate ) mod private
 
   impl HelpGeneratorFn
   {
-    /// Executes the function
+    /// Executes the function to generate help content
     pub fn exec( &self, grammar : &GrammarConverter, command : Option< &Command > ) -> String
     {
       self.0( grammar, command )

--- a/rust/impl/ca/ca/parser/command.rs
+++ b/rust/impl/ca/ca/parser/command.rs
@@ -52,7 +52,7 @@ pub( crate ) mod private
         {
           Command
           {
-            name : name.to_owned(),
+            name : name.to_string(),
             subjects : subjects.into_iter().filter_map( |( _, subject )| if subject.is_empty() { None } else { Some( subject ) } ).collect(),
             properties : props.into_iter().map( |( _, prop )| prop ).collect()
           }
@@ -202,7 +202,7 @@ pub( crate ) mod private
 
   impl CommandParser for Parser
   {
-    fn command< 'a >( &'a self, input : &'a str ) -> Result< Command >
+    fn command( &self, input : &str ) -> Result< Command >
     {
       self.command_fn()( input )
       .map( |( _, command )| command )

--- a/rust/impl/ca/ca/parser/entities.rs
+++ b/rust/impl/ca/ca/parser/entities.rs
@@ -22,7 +22,7 @@ pub( crate ) mod private
   #[ derive( Debug, Clone, PartialEq, Eq ) ]
   pub struct RawCommand
   {
-    /// name of command without delimeter
+    /// name of command without delimiter
     pub name : String,
     /// list of subjects
     pub subjects : Vec< String >,

--- a/rust/impl/ca/ca/parser/namespace.rs
+++ b/rust/impl/ca/ca/parser/namespace.rs
@@ -68,7 +68,7 @@ pub( crate ) mod private
 
   impl NamespaceParser for Parser
   {
-    fn namespace< 'a >( &'a self, input : &'a str ) -> Result< Namespace< RawCommand > >
+    fn namespace( &self, input : &str ) -> Result< Namespace< RawCommand > >
     {
       self.namespace_fn()( input.trim() )
       .map( |( _, namespace )| namespace )

--- a/rust/impl/ca/ca/parser/program.rs
+++ b/rust/impl/ca/ca/parser/program.rs
@@ -47,7 +47,7 @@ pub( crate ) mod private
 
   impl ProgramParser for Parser
   {
-    fn program< 'a >( &'a self, input : &'a str ) -> Result< Program< Namespace< RawCommand > > >
+    fn program( &self, input : &str ) -> Result< Program< Namespace< RawCommand > > >
     {
       self.program_fn()( input.trim() )
       .map( |( _, program )| program )

--- a/rust/test/ca/inc/commands_aggregator/mod.rs
+++ b/rust/test/ca/inc/commands_aggregator/mod.rs
@@ -10,4 +10,34 @@ use wca::
   HelpVariants
 };
 
-mod basic;
+// mod basic;
+
+#[test]
+fn static_grammar() {
+  // TODO: rework it to generate by macro
+  let ca = CommandsAggregator::former()
+  .grammar
+  (
+    &phf::phf_map!
+    (
+      "command" => &[
+        wca::StaticGrammarCommand
+        {
+          hint : "",
+          long_hint : "",
+          phrase : "command",
+          subjects : &[],
+          properties : phf::phf_map!(),
+          properties_aliases : phf::phf_map!(),
+        }
+      ]
+    )
+  )
+  .executor(
+  [
+    ( "command".to_owned(), Routine::new( | _ | { println!( "Command" ); Ok( () ) } ) ),
+  ])
+  .build();
+
+  ca.perform( ".command" ).unwrap();
+}


### PR DESCRIPTION
- [ ] Write static equivalents for `GrammarConverter` and `Command`
- [ ] Make help commands work with it
- [ ] Replace `GrammarConverter` and `Command` with it equivalents
- [ ] Write macro to construct it comfortable
