### PR TITLE
READY: wca lifetimes fix

### DIFF
--- a/module/move/wca/src/ca/facade.rs
+++ b/module/move/wca/src/ca/facade.rs
@@ -220,7 +220,7 @@ pub( crate ) mod private
     /// The modified command instance with the properties added.
     ///
     #[ inline ]
-    pub fn properties< const N: usize >( mut self, properties : [ Property; N ] ) -> Self
+    pub fn properties< const N: usize >( mut self, properties : [ Property< '_ >; N ] ) -> Self
     {
       self.command.properties.reserve( properties.len() );
 
@@ -301,7 +301,7 @@ pub( crate ) mod private
     }
 
     /// Adds properties to the command.
-    fn properties< const N: usize >( self, properties: [ Property; N ] ) -> Builder< Self >
+    fn properties< const N: usize >( self, properties: [ Property< '_ >; N ] ) -> Builder< Self >
     {
       Builder::new( self ).properties( properties )
     }

--- a/module/move/wca/src/ca/parser/command.rs
+++ b/module/move/wca/src/ca/parser/command.rs
@@ -38,7 +38,7 @@ pub( crate ) mod private
   pub trait CommandParserFn : GetCommandPrefix + CommandNameParserFn + CommandSubjectParserFn + CommandPropertyParserFn
   {
     /// Returns function that can parse a Command
-    fn command_fn( &self ) -> CommandParserFunction
+    fn command_fn( &self ) -> CommandParserFunction< '_ >
     {
       let command_prefix = self.get_command_prefix();
       Box::new( move | input : &str |
@@ -122,7 +122,7 @@ pub( crate ) mod private
   pub trait CommandSubjectParserFn
   {
     /// Returns function that can parse a Command subject
-    fn command_subject_fn( &self ) -> CommandSubjectParserFunction;
+    fn command_subject_fn( &self ) -> CommandSubjectParserFunction< '_ >;
   }
 
   type CommandPropertyParserFunction< 'a > = Box< dyn Fn( &str ) -> IResult< &str, ( String, String ) > + 'a >;
@@ -131,7 +131,7 @@ pub( crate ) mod private
   pub trait CommandPropertyParserFn
   {
     /// Returns function that can parse a Command property
-    fn command_property_fn( &self ) -> CommandPropertyParserFunction;
+    fn command_property_fn( &self ) -> CommandPropertyParserFunction< '_ >;
   }
 
   impl CommandNameParserFn for Parser
@@ -152,7 +152,7 @@ pub( crate ) mod private
 
   impl CommandSubjectParserFn for Parser
   {
-    fn command_subject_fn( &self ) -> CommandSubjectParserFunction
+    fn command_subject_fn( &self ) -> CommandSubjectParserFunction< '_ >
     {
       // ? looks not good
       // reason - all words can be `subject`
@@ -207,7 +207,7 @@ pub( crate ) mod private
 
   impl CommandPropertyParserFn for Parser
   {
-    fn command_property_fn( &self ) -> CommandPropertyParserFunction
+    fn command_property_fn( &self ) -> CommandPropertyParserFunction< '_ >
     {
       let property_delimeter = self.prop_delimeter;
       Box::new

--- a/module/move/wca/src/ca/parser/namespace.rs
+++ b/module/move/wca/src/ca/parser/namespace.rs
@@ -48,7 +48,7 @@ pub( crate ) mod private
   pub( crate ) trait NamespaceParserFn : CommandParserFn + GetNamespaceDelimeter
   {
     /// Returns function that can parse a Namespace
-    fn namespace_fn( &self ) -> NamespaceParserFunction
+    fn namespace_fn( &self ) -> NamespaceParserFunction< '_ >
     {
       let delimeter = self.get_namespace_delimeter();
       Box::new

--- a/module/move/wca/src/ca/parser/program.rs
+++ b/module/move/wca/src/ca/parser/program.rs
@@ -28,7 +28,7 @@ pub( crate ) mod private
   pub( crate ) trait ProgramParserFn : NamespaceParserFn
   {
     /// Returns function that can parse a Namespace
-    fn program_fn( &self ) -> ProgramParserFunction
+    fn program_fn( &self ) -> ProgramParserFunction< '_ >
     {
       Box::new
       (


### PR DESCRIPTION
The current version of wca did not build on version 1.74, with an errors like:
```
error: hidden lifetime parameters in types are deprecated
  --> module\move\wca\src\ca\parser\program.rs:31:31
|
|     fn program_fn( &self ) -> ProgramParserFunction
|                               ^^^^^^^^^^^^^^^^^^^^^ expected lifetime parameter
|
help: indicate the anonymous lifetime
|
|     fn program_fn( &self ) -> ProgramParserFunction<'_>
|                                                    ++++
```