### PR TITLE
READY : (wca) optional subjects

### DIFF
--- a/module/move/wca/src/lib.rs
+++ b/module/move/wca/src/lib.rs
@@ -18,7 +18,7 @@
 
 use mod_interface::mod_interface;
 /// Tools
-mod wtools;
+pub mod wtools;
 
 /// Errors.
 #[ cfg( not( feature = "no_std" ) ) ]

--- a/module/move/wca/tests/inc/executor/command.rs
+++ b/module/move/wca/tests/inc/executor/command.rs
@@ -48,7 +48,7 @@ tests_impls!
       .hint( "hint" )
       .long_hint( "long_hint" )
       .phrase( "command" )
-      .subject( "hint", Type::String, true )
+      .subject( "hint", Type::String, false )
       .form()
     )
     .form();


### PR DESCRIPTION
```rust
wca::Command::former()
      .hint( "hint" )
      .long_hint( "long_hint" )
      .phrase( "command" )
      .subject( "This subject is optional", Type::String, true )
      .form()
```
accepts both calls: `.command` and `.command with_subject`