### PR TITLE
READY: (workflow): Fix newline issue in commit message extraction

### DIFF
--- a/.github/workflows/StandardRustPullRequest.yml
+++ b/.github/workflows/StandardRustPullRequest.yml
@@ -33,7 +33,7 @@ jobs :
           length=$(jq 'length' response.json)
           index=$(($length - 1))
           latest_commit=$(jq --argjson index $index '.[$index]' response.json)
-          latest_commit_message=$(echo "$latest_commit" | jq -r '.commit.message')
+          latest_commit_message=$(echo "$latest_commit" | jq -r '.commit.message' | tr -d '\n')
           echo "message=$latest_commit_message" >> $GITHUB_OUTPUT
       - name : Set output
         id: run


### PR DESCRIPTION
This change updates the StandardRustPullRequest.yml GitHub action workflow, specifically the extraction of the latest commit message. Now, any newline characters are removed from the commit message, ensuring accurate capture of the message for any further processing or output.