### PR TITLE
READY:  (wpublisher) Enable list command in publisher module, update error handling

### DIFF
--- a/module/move/wpublisher/src/publisher/commands/init.rs
+++ b/module/move/wpublisher/src/publisher/commands/init.rs
@@ -70,7 +70,7 @@ pub( crate ) mod private
     ([
       ( "publish".to_owned(), Routine::new( crate::commands::publish::publish ) ),
       ( "workspace.publish".to_owned(), Routine::new( crate::commands::publish::workspace_publish ) ),
-      // ( "list".to_owned(), Routine::new( crate::commands::list::list ) ),
+      ( "list".to_owned(), Routine::new( crate::commands::list::list ) ),
     ])
   }
 }

--- a/module/move/wpublisher/src/publisher/commands/list.rs
+++ b/module/move/wpublisher/src/publisher/commands/list.rs
@@ -4,13 +4,13 @@ pub( crate ) mod private
   use crate::protected::*;
   use std::env;
   use wca::{ Args, Props };
-  use wca::wtools::error::BasicError;
+  use wca::wtools::error::Result;
 
   ///
   /// List packages.
   ///
 
-  pub fn list( ( args, _ ) : ( Args, Props ) ) -> Result< (), BasicError >
+  pub fn list( ( args, _ ) : ( Args, Props ) ) -> Result< () >
   {
     let current_path = env::current_dir().unwrap();
 

--- a/module/move/wpublisher/tests/publisher/inc/publisher_test.rs
+++ b/module/move/wpublisher/tests/publisher/inc/publisher_test.rs
@@ -88,11 +88,11 @@ tests_impls!
     #[ cfg( not( debug_assertions ) ) ]
     let path = std::ffi::OsStr::new( "../../../target/release/wpublisher" );
     let proc = std::process::Command::new( path ).arg( ".list" ).output().unwrap();
-    assert!( !proc.status.success() );
+    assert!( proc.status.success() );
     let stdout = std::str::from_utf8( proc.stdout.as_slice() ).unwrap();
     assert_eq!( stdout, "" );
     let stderr = std::str::from_utf8( proc.stderr.as_slice() ).unwrap();
-    assert_eq!( stderr, "Error: Validation(ExecutorConverter(Can not found routine for command `list`))\n" );
+    assert_eq!( stderr, "" );
   }
 
   //


### PR DESCRIPTION
The list command in the publisher module was uncommented in the Routine's construct, activating it for use. Additionally, the error handling in the "list" function was updated from BasicError as expected by Routine. These changes were reflected in the unit tests where successful command execution is now verified.