### PR TITLE
READY: (willbe): Improve test failure detection and enable nightly testing by default

### DIFF
--- a/module/move/willbe/src/command/run_tests.rs
+++ b/module/move/willbe/src/command/run_tests.rs
@@ -19,7 +19,7 @@ mod private
   {
     #[ default( true ) ]
     with_stable : bool,
-    #[ default( false ) ]
+    #[ default( true ) ]
     with_nightly : bool,
     #[ default( true ) ]
     parallel : bool,

--- a/module/move/willbe/src/endpoint/run_tests.rs
+++ b/module/move/willbe/src/endpoint/run_tests.rs
@@ -42,15 +42,17 @@ mod private
 			{
 				for (feature, result) in features
 				{
-					if !result.out.contains( "failures" )
+					// if tests failed or if build failed
+					let failed = result.out.contains( "failures" ) || result.err.contains( "error" );
+					if !failed
 					{
 						let feature = if feature.is_empty() { "no-features" } else { feature };
-						f.write_fmt(format_args!("  [ {} | {} ]: {}\n", channel, feature, if result.out.contains("failures") { "❌ failed" } else { "✅ successful" } ) )?;
+						f.write_fmt(format_args!("  [ {} | {} ]: {}\n", channel, feature, if failed { "❌ failed" } else { "✅ successful" } ) )?;
 					}
 					else
 					{
 						let feature = if feature.is_empty() { "no-features" } else { feature };
-						f.write_fmt( format_args!( "  Feature: [ {} | {} ]:\n  Tests status: {}\n{}\n", channel, feature, if result.out.contains( "failures" ) { "❌ failed" } else { "✅ successful" }, result.out ) )?;
+						f.write_fmt( format_args!( "  Feature: [ {} | {} ]:\n  Tests status: {}\n{}\n{}", channel, feature, if failed { "❌ failed" } else { "✅ successful" }, result.out, result.err ) )?;
 					}
 				}
 			}


### PR DESCRIPTION
The testing sections of two modules were updated. Fault detection was improved in the `run_tests.rs` file in the `endpoint` module to not only report failures but also consider build errors. Similarly, the `run_tests.rs` file in the `command` module was updated to enable the `with_nightly` flag by default - thus ensuring more thorough testing with the latest versions.