### PR TITLE
READY : (willbe): Refactor Testing Infrastructure and Add Dry Run Mode

### DIFF
--- a/module/move/willbe/src/command/mod.rs
+++ b/module/move/willbe/src/command/mod.rs
@@ -47,6 +47,7 @@ pub( crate ) mod private
     .long_hint( "this command runs tests in designated packages based on the provided path. It allows for inclusion and exclusion of features, testing on different Rust version channels, parallel execution, and feature combination settings." )
     .phrase( "test" )
     .subject( "A path to directories with packages. If no path is provided, the current directory is used.", Type::Path, true )
+    .property( "dry", "Enables 'dry run'. Does not run tests, only simulates. Default is `true`.", Type::Bool, true )
     .property( "include", "A list of features to include in testing. Separate multiple features by comma.", Type::List( Type::String.into(), ',' ), true )
     .property( "exclude", "A list of features to exclude from testing. Separate multiple features by comma.", Type::List( Type::String.into(), ',' ), true )
     .property( "with_stable", "Specifies whether or not to run tests on stable Rust version. Default is `true`", Type::Bool, true )

--- a/module/move/willbe/src/command/mod.rs
+++ b/module/move/willbe/src/command/mod.rs
@@ -45,7 +45,7 @@ pub( crate ) mod private
     let run_tests_command = wca::Command::former()
     .hint( "execute tests in specific packages" )
     .long_hint( "this command runs tests in designated packages based on the provided path. It allows for inclusion and exclusion of features, testing on different Rust version channels, parallel execution, and feature combination settings." )
-    .phrase("tests.run")
+    .phrase( "test" )
     .subject( "A path to directories with packages. If no path is provided, the current directory is used.", Type::Path, true )
     .property( "include", "A list of features to include in testing. Separate multiple features by comma.", Type::List( Type::String.into(), ',' ), true )
     .property( "exclude", "A list of features to exclude from testing. Separate multiple features by comma.", Type::List( Type::String.into(), ',' ), true )
@@ -105,7 +105,7 @@ pub( crate ) mod private
       ( "publish".to_owned(), Routine::new( publish ) ),
       ( "list".to_owned(), Routine::new( list ) ),
       ( "readme.health.table.generate".to_owned(), Routine::new( table_generate ) ),
-      ( "tests.run".to_owned(), Routine::new( run_tests ) ),
+      ( "test".to_owned(), Routine::new( test ) ),
       ( "workflow.generate".to_owned(), Routine::new( workflow_generate ) ),
       ( "workspace.new".to_owned(), Routine::new( workspace_new ) ),
       ( "readme.header.generate".to_owned(), Routine::new( main_header_generate ) ),
@@ -127,7 +127,7 @@ crate::mod_interface!
   /// Generate tables
   layer table;
   /// Run all tests
-  layer run_tests;
+  layer test;
   /// Generate workflow
   layer workflow;
   /// Workspace new

--- a/module/move/willbe/src/command/test.rs
+++ b/module/move/willbe/src/command/test.rs
@@ -18,6 +18,8 @@ mod private
   struct TestsProperties
   {
     #[ default( true ) ]
+    dry : bool,
+    #[ default( true ) ]
     with_stable : bool,
     #[ default( true ) ]
     with_nightly : bool,
@@ -34,7 +36,7 @@ mod private
 	{
     let path : PathBuf = args.get_owned( 0 ).unwrap_or_else( || "./".into() );
     let path = AbsolutePath::try_from( path )?;
-    let TestsProperties { with_stable, with_nightly, parallel, power, include, exclude } = properties.try_into()?;
+    let TestsProperties { dry, with_stable, with_nightly, parallel, power, include, exclude } = properties.try_into()?;
 
     let crate_dir = CrateDir::try_from( path )?;
 
@@ -51,7 +53,7 @@ mod private
     .include_features( include )
     .form();
 
-    match endpoint::test( args )
+    match endpoint::test( args, dry )
     {
       Ok( report ) =>
       {
@@ -74,6 +76,7 @@ mod private
     {
       let mut this = Self::former();
 
+      this = if let Some( v ) = value.get_owned( "dry" ) { this.dry::< bool >( v ) } else { this };
       this = if let Some( v ) = value.get_owned( "with_stable" ) { this.with_stable::< bool >( v ) } else { this };
       this = if let Some( v ) = value.get_owned( "with_nightly" ) { this.with_nightly::< bool >( v ) } else { this };
       this = if let Some( v ) = value.get_owned( "parallel" ) { this.parallel::< bool >( v ) } else { this };

--- a/module/move/willbe/src/command/test.rs
+++ b/module/move/willbe/src/command/test.rs
@@ -10,12 +10,12 @@ mod private
   use wca::{ Args, Props };
   use wtools::error::Result;
   use path::AbsolutePath;
-  use endpoint::run_tests::TestsArgs;
+  use endpoint::test::TestsArgs;
   use former::Former;
   use cargo::Channel;
 
   #[ derive( Former ) ]
-  struct RunTestsProperties
+  struct TestsProperties
   {
     #[ default( true ) ]
     with_stable : bool,
@@ -30,11 +30,11 @@ mod private
   }
 
   /// run tests in specified crate
-	pub fn run_tests( ( args, properties ) : ( Args, Props ) ) -> Result< () >
+	pub fn test( ( args, properties ) : ( Args, Props ) ) -> Result< () >
 	{
     let path : PathBuf = args.get_owned( 0 ).unwrap_or_else( || "./".into() );
     let path = AbsolutePath::try_from( path )?;
-    let RunTestsProperties { with_stable, with_nightly, parallel, power, include, exclude } = properties.try_into()?;
+    let TestsProperties { with_stable, with_nightly, parallel, power, include, exclude } = properties.try_into()?;
 
     let crate_dir = CrateDir::try_from( path )?;
 
@@ -51,7 +51,7 @@ mod private
     .include_features( include )
     .form();
 
-    match endpoint::run_tests( args )
+    match endpoint::test( args )
     {
       Ok( report ) =>
       {
@@ -67,7 +67,7 @@ mod private
     }
 	}
 
-  impl TryFrom< Props > for RunTestsProperties
+  impl TryFrom< Props > for TestsProperties
   {
     type Error = wtools::error::for_app::Error;
     fn try_from( value : Props ) -> Result< Self, Self::Error >
@@ -89,5 +89,5 @@ mod private
 crate::mod_interface!
 {
   /// run tests in specified crate
-  exposed use run_tests;
+  exposed use test;
 }

--- a/module/move/willbe/src/endpoint/mod.rs
+++ b/module/move/willbe/src/endpoint/mod.rs
@@ -7,7 +7,7 @@ crate::mod_interface!
   /// Tables.
   layer table;
   /// Run all tests
-  layer run_tests;
+  layer test;
   /// Workflow.
   layer workflow;
   /// Workspace new.

--- a/module/move/willbe/src/endpoint/test.rs
+++ b/module/move/willbe/src/endpoint/test.rs
@@ -92,7 +92,7 @@ mod private
 	/// It is possible to enable and disable various features of the crate.
 	/// The function also has the ability to run tests in parallel using `Rayon` crate.
 	/// The result of the tests is written to the structure `TestReport` and returned as a result of the function execution.
-	pub fn run_tests( args : TestsArgs ) -> Result< TestReport, ( TestReport, Error ) >
+	pub fn test( args : TestsArgs ) -> Result< TestReport, ( TestReport, Error ) >
 	{
     let report = TestReport::default();
 		// fail fast if some additional installations required
@@ -160,7 +160,7 @@ mod private
 crate::mod_interface!
 {
   /// run all tests in all crates
-  exposed use run_tests;
+  exposed use test;
 	protected use TestsArgs;
   protected use TestReport;
 }

--- a/module/move/willbe/tests/inc/endpoints/tests_run.rs
+++ b/module/move/willbe/tests/inc/endpoints/tests_run.rs
@@ -4,8 +4,8 @@ use std::path::{ Path, PathBuf };
 use assert_fs::TempDir;
 
 use crate::TheModule::*;
-use endpoint::run_tests;
-use endpoint::run_tests::TestReport;
+use endpoint::test::{ test, TestsArgs };
+use endpoint::test::TestReport;
 use path::AbsolutePath;
 
 #[ test ]
@@ -27,12 +27,12 @@ fn fail_test()
   let abs = AbsolutePath::try_from( project ).unwrap();
   let crate_dir = CrateDir::try_from( abs ).unwrap();
 
-  let args = run_tests::TestsArgs::former()
+  let args = TestsArgs::former()
   .dir( crate_dir )
   .channels([ cargo::Channel::Stable ])
   .form();
 
-  let rep : TestReport = run_tests( args ).unwrap_err().0;
+  let rep : TestReport = test( args ).unwrap_err().0;
   println!( "========= OUTPUT =========\n{}\n==========================", rep );
 
   let stable = rep.tests.get( &cargo::Channel::Stable ).unwrap();
@@ -61,12 +61,12 @@ fn fail_build()
   let abs = AbsolutePath::try_from( project ).unwrap();
   let crate_dir = CrateDir::try_from( abs ).unwrap();
 
-  let args = run_tests::TestsArgs::former()
+  let args = TestsArgs::former()
   .dir( crate_dir )
   .channels([ cargo::Channel::Stable ])
   .form();
 
-  let rep: TestReport = run_tests( args ).unwrap_err().0;
+  let rep: TestReport = test( args ).unwrap_err().0;
   println!( "========= OUTPUT =========\n{}\n==========================", rep );
 
   let stable = rep.tests.get( &cargo::Channel::Stable ).unwrap();


### PR DESCRIPTION
'run_tests' Function and References Renamed: To improve the readability and consistency across our codebase, we've renamed the 'run_tests' function to 'test'. This update touches multiple files—anywhere 'run_tests' was referred to or imported, we've updated it to 'test'.
Added Dry Run Mode to Testing Endpoint: We introduced a 'dry run' mode to our test endpoint. This new mode enables a simulated execution of tests without actual running, which is useful for various test planning and development scenarios. We added a 'dry' boolean flag to our 'TestReport' struct—toggling this flag enables you to switch the mode on and off. Also, with this update, we've made several adjustments to how test display outputs are presented, enhancing clarity and readability.