### PR TITLE
READY : (willbe) Cascade Package Publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,12 +406,12 @@ default-features = true
 ## test experimental
 
 [workspace.dependencies.test_experimental_a]
-version = "~0.1.0"
+version = "~0.2.0"
 path = "module/test/a"
 default-features = true
 
 [workspace.dependencies.test_experimental_b]
-version = "~0.1.0"
+version = "~0.2.0"
 path = "module/test/b"
 default-features = true
 

--- a/module/move/willbe/src/command/workspace_new.rs
+++ b/module/move/willbe/src/command/workspace_new.rs
@@ -5,7 +5,6 @@ mod private
 
   use wca::{ Args, Props };
   use wtools::error::{ anyhow::Context, Result };
-  use crate::endpoint::list::ListFormat;
 
   #[ derive( Former ) ]
   struct WorkspaceNewProperties

--- a/module/move/willbe/src/endpoint/publish.rs
+++ b/module/move/willbe/src/endpoint/publish.rs
@@ -3,10 +3,7 @@ mod private
 {
   use crate::*;
 
-  use std::
-  {
-    collections::{ HashSet, HashMap }, io,
-  };
+  use std::collections::{ HashSet, HashMap };
   use core::fmt::Formatter;
   use petgraph::prelude::*;
 
@@ -108,51 +105,59 @@ mod private
     // find all packages by specified folders
     for pattern in &patterns
     {
-      let current_path = AbsolutePath::try_from( std::path::PathBuf::from( pattern ) ).map_err( | e | ( report.clone(), e.into() ) )?;
+      let current_path = AbsolutePath::try_from( std::path::PathBuf::from( pattern ) ).err_with( || report.clone() )?;
       // let current_paths = files::find( current_path, &[ "Cargo.toml" ] );
       paths.extend( Some( current_path ) );
     }
 
     let mut metadata = if paths.is_empty()
     {
-      Workspace::from_current_path().map_err( | e | ( report.clone(), e.into() ) )?
+      Workspace::from_current_path().err_with( || report.clone() )?
     }
     else
     {
       // FIX: patterns can point to different workspaces. Current solution take first random path from list
       let current_path = paths.iter().next().unwrap().clone();
-      let dir = CrateDir::try_from( current_path ).map_err( | e | ( report.clone(), e.into() ) )?;
+      let dir = CrateDir::try_from( current_path ).err_with( || report.clone() )?;
 
-      Workspace::with_crate_dir( dir ).map_err( | err | ( report.clone(), anyhow!( err ) ) )?
+      Workspace::with_crate_dir( dir ).err_with( || report.clone() )?
     };
     report.workspace_root_dir = Some
     ( 
       metadata
       .workspace_root()
-      .map_err( | err | ( report.clone(), anyhow!( err ) ) )?
+      .err_with( || report.clone() )?
       .try_into()
-      .map_err( | err: io::Error | ( report.clone(), anyhow!( err ) ) )?
+      .err_with( || report.clone() )?
     );
-    let packages_to_publish : Vec< _ >= metadata
-    .load()
-    .map_err( | err | ( report.clone(), anyhow!( err ) ) )?
-    .packages()
-    .map_err( | err | ( report.clone(), anyhow!( err ) ) )?
+    let packages = metadata.load().err_with( || report.clone() )?.packages().err_with( || report.clone() )?;
+    let packages_to_publish : Vec< _ > = packages
     .iter()
     .filter( | &package | paths.contains( &AbsolutePath::try_from( package.manifest_path.as_std_path().parent().unwrap() ).unwrap() ) )
     .map( | p | p.name.clone() )
     .collect();
-    let package_map = metadata.packages().unwrap().into_iter().map( | p | ( p.name.clone(), Package::from( p.clone() ) ) ).collect::< HashMap< _, _ > >();
+    let package_map = packages.into_iter().map( | p | ( p.name.clone(), Package::from( p.clone() ) ) ).collect::< HashMap< _, _ > >();
 
-    let graph = graph( &metadata );
-    let subgraph_wanted = subgraph( &graph, &packages_to_publish );
+    let graph = metadata.graph();
+    let subgraph_wanted = graph::subgraph( &graph, &packages_to_publish );
     let reversed_subgraph =
     {
-      let roots = subgraph_wanted.node_indices().map( | i | &graph[ subgraph_wanted[ i ] ] ).filter_map( | n | package_map.get( n ).map( | p | ( n, p ) ) ).inspect( |( _, p )| { cargo::package( p.crate_dir(), false ).unwrap(); } ).filter( |( _, package )| publish_need( package ).unwrap() ).map( |( name, _ )| name.clone() ).collect::< Vec< _ > >();
+      let roots = subgraph_wanted
+      .node_indices()
+      .map( | i | &graph[ subgraph_wanted[ i ] ] )
+      .filter_map( | n | package_map.get( n )
+      .map( | p | ( n, p ) ) )
+      .map( |( n, p )| cargo::package( p.crate_dir(), false ).map( | _ | ( n, p ) ) )
+      .collect::< Result< Vec< _ >, _ > >()
+      .err_with( || report.clone() )?
+      .into_iter()
+      .filter( |( _, package )| publish_need( package ).unwrap() )
+      .map( |( name, _ )| name.clone() )
+      .collect::< Vec< _ > >();
 
       let mut reversed = graph.clone();
       reversed.reverse();
-      subgraph( &reversed, &roots )
+      graph::subgraph( &reversed, &roots )
     };
     {
       for node in reversed_subgraph.node_indices()
@@ -164,7 +169,7 @@ mod private
         }
       }
     }
-    let subgraph = reversed_subgraph.map( | _, y | &graph[ *y ], | _, y | &graph[ subgraph_wanted[ *y ] ] );
+    let subgraph = reversed_subgraph.map( | _, y | &graph[ *y ], | _, y | &graph[ *y ] );
 
     let queue = graph::toposort( subgraph ).unwrap().into_iter().map( | n | package_map.get( &n ).unwrap() ).rev().collect::< Vec< _ > >();
 
@@ -185,66 +190,23 @@ mod private
     Ok( report )
   }
 
-  fn graph( workspace : &Workspace ) -> Graph< String, String >
+  trait ErrWith< T, T1, E >
   {
-    let packages = workspace.packages().unwrap();
-    let module_package_filter: Option< Box< dyn Fn( &cargo_metadata::Package ) -> bool > > = Some
-    (
-      Box::new( move | p | p.publish.is_none() )
-    );
-    let module_dependency_filter: Option< Box< dyn Fn( &cargo_metadata::Package, &cargo_metadata::Dependency) -> bool > > = Some
-    (
-      Box::new
-      (
-        move | _, d | d.path.is_some() && d.kind != cargo_metadata::DependencyKind::Development
-      )
-    );
-    let module_packages_map = packages::filter
-    (
-      packages,
-      packages::FilterMapOptions { package_filter: module_package_filter, dependency_filter: module_dependency_filter },
-    );
-
-    graph::construct( &module_packages_map ).map( | _, x | x.to_string(), | _, x | x.to_string() )
+    fn err_with< F >( self, f : F ) -> std::result::Result< T1, ( T, E ) >
+    where
+      F : FnOnce() -> T;
   }
 
-  fn subgraph( graph : &Graph< String, String >, roots : &[ String ] ) -> Graph< NodeIndex, NodeIndex >
+  impl< T, T1, E > ErrWith< T, T1, Error > for Result< T1, E >
+  where
+    E : std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
   {
-    let mut subgraph = Graph::new();
-    let mut node_map = HashMap::new();
-
-    for root in roots
+    fn err_with< F >( self, f : F ) -> Result< T1, ( T, Error ) >
+    where
+      F : FnOnce() -> T,
     {
-      let root_id = graph.node_indices().find( | x | &graph[ *x ] == root ).unwrap();
-      let mut dfs = Dfs::new( graph, root_id );
-      while let Some( nx ) = dfs.next( &graph )
-      {
-        if !node_map.contains_key( &nx )
-        {
-          let sub_node = subgraph.add_node( nx );
-          node_map.insert( nx, sub_node );
-        }
-      }
+      self.map_err( | e | ( f(), anyhow!( e ) ) )
     }
-
-    for ( _, sub_node_id ) in &node_map
-    {
-      let node_id_graph = subgraph[ *sub_node_id ];
-
-      for edge in graph.edges( node_id_graph )
-      {
-        match ( node_map.get( &edge.source() ), node_map.get( &edge.target() ) )
-        {
-          ( Some( &from ), Some( &to ) ) =>
-          {
-            subgraph.add_edge( from, to, from );
-          }
-          _ => {}
-        }
-      }
-    }
-
-    subgraph
   }
 }
 

--- a/module/move/willbe/src/endpoint/workflow.rs
+++ b/module/move/willbe/src/endpoint/workflow.rs
@@ -22,7 +22,7 @@ mod private
   /// Generate workflows for modules in .github/workflows directory.
   pub fn workflow_generate( base_path : &Path ) -> Result< () >
   {
-    let mut workspace_cache = Workspace::with_crate_dir( AbsolutePath::try_from( base_path )?.try_into()? )?;
+    let workspace_cache = Workspace::with_crate_dir( AbsolutePath::try_from( base_path )?.try_into()? )?;
     let packages = workspace_cache.packages()?;
     let username_and_repository = &username_and_repository( &workspace_cache.workspace_root()?.join( "Cargo.toml" ).try_into()?, packages )?;
     let workspace_root = workspace_cache.workspace_root()?;

--- a/module/move/willbe/tests/inc/publish_need.rs
+++ b/module/move/willbe/tests/inc/publish_need.rs
@@ -1,12 +1,20 @@
 use super::*;
 
-use std::path::{ Path, PathBuf };
+use std::
+{
+  io::Write,
+  path::{ Path, PathBuf },
+};
 
 use assert_fs::prelude::*;
-use TheModule::{ manifest, version, cargo };
-use TheModule::package::protected::publish_need;
-use TheModule::package::Package;
-use TheModule::path::AbsolutePath;
+use TheModule::
+{
+  package::{ publish_need, Package },
+  path::AbsolutePath,
+  manifest,
+  version,
+  cargo
+};
 
 const TEST_MODULE_PATH : &str = "../../test/";
 
@@ -14,6 +22,15 @@ fn package_path< P : AsRef< Path > >( path : P ) -> PathBuf
 {
   let root_path = Path::new( env!( "CARGO_MANIFEST_DIR" ) ).join( TEST_MODULE_PATH );
   root_path.join( path )
+}
+
+fn package< P : AsRef< Path > >( path : P ) -> Package
+{
+  let path = path.as_ref();
+  _ = cargo::package( path, false ).expect( "Failed to package a package" );
+  let absolute = AbsolutePath::try_from( path ).unwrap();
+
+  Package::try_from( absolute ).unwrap()
 }
 
 // published the same as local
@@ -60,4 +77,58 @@ fn with_changes()
 
   // Assert
   assert!( publish_needed );
+}
+
+// c(update) -> b(re-publish) -> a(re-publish)
+#[ test ]
+fn cascade_with_changes()
+{
+  let abc = [ "a", "b", "c" ].into_iter().map( package_path ).map( package ).collect::< Vec< _ > >();
+  let [ a, b, c ] = abc.as_slice() else { unreachable!() };
+  if ![ c, b, a ].into_iter().inspect( | x | { dbg!( x.name().unwrap() ); } ).map( publish_need ).inspect( | x | { dbg!(x); } ).all( | p | !p.expect( "There was an error verifying whether the package needs publishing or not" ) )
+  {
+    panic!( "The packages must be up-to-dated" );
+  }
+  let temp = assert_fs::TempDir::new().unwrap();
+  let temp_module = temp.child( "module" );
+  std::fs::create_dir( &temp_module ).unwrap();
+  temp_module.child( "a" ).copy_from( a.manifest_path().parent().unwrap(), &[ "**" ] ).unwrap();
+  temp_module.child( "b" ).copy_from( b.manifest_path().parent().unwrap(), &[ "**" ] ).unwrap();
+  temp_module.child( "c" ).copy_from( c.manifest_path().parent().unwrap(), &[ "**" ] ).unwrap();
+  let a_temp_path = temp_module.join( "a" );
+  let b_temp_path = temp_module.join( "b" );
+  let c_temp_path = temp_module.join( "c" );
+
+  let mut cargo_toml = std::fs::File::create( temp.join( "Cargo.toml" ) ).unwrap();
+  write!( cargo_toml, r#"
+[workspace]
+resolver = "2"
+members = [
+    "module/*",
+]
+[workspace.dependencies.test_experimental_a]
+version = "*"
+path = "module/a"
+default-features = true
+[workspace.dependencies.test_experimental_b]
+version = "*"
+path = "module/b"
+default-features = true
+[workspace.dependencies.test_experimental_c]
+version = "*"
+path = "module/c"
+default-features = true
+"# ).unwrap();
+
+  let absolute = AbsolutePath::try_from( c_temp_path.join( "Cargo.toml" ) ).unwrap();
+  let mut manifest = manifest::open( absolute ).unwrap();
+  version::bump( &mut manifest, false ).unwrap();
+  
+  let c_temp = package( c_temp_path );
+  let b_temp = package( b_temp_path );
+  let a_temp = package( a_temp_path );
+
+  assert!( publish_need( &c_temp ).unwrap() );
+  assert!( publish_need( &b_temp ).unwrap() );
+  assert!( publish_need( &a_temp ).unwrap() );
 }

--- a/module/test/a/Cargo.toml
+++ b/module/test/a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_experimental_a"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = """

--- a/module/test/b/Cargo.toml
+++ b/module/test/b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_experimental_b"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = """


### PR DESCRIPTION
In this pull request, a new method of handling package publishing in the project is introduced. In the previous system, when a user requested a package to be published, the solution only looked at the package's dependencies and recursively updated them if required. While this approach was functional, it did not account for packages that depended on the requested package. Thus, not every relevant package was getting published.
In this updated system, the dependency graph is now analysed in both directions - not only looking at the package's dependencies but also at its dependents. When a package is requested to be published, the solution identifies its dependencies that require updates, then the dependency graph is reversed. After reversing, all packages that depend on the updated packages are also published. This optimizes the dependency handling and ensures that all the relevant packages, whether they are dependencies or dependents, are taken into account for publishing.
Consider a project with package 'a' depending on 'b' which depends on 'c' (a -> b -> c). With the previous system, if the user requested to publish 'b', only 'c' would be updated and published. But with the current system, since updating 'c', influences 'b' and 'a', it ensures all relevant packages 'a', 'b', and 'c' are published.

# Example
1) Project
![project](https://i.imgur.com/FDYu8tN.png)
2) Want to publish: `B`. Required to publish: `E`
![subgraph](https://i.imgur.com/Jhu2cGx.png)
3) `E` can affect `C`, `B`, `A`
![reversed subgraph](https://i.imgur.com/LrKET1p.png)