### PR TITLE
READ : (willbe) Updated Package Publishing Criteria

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -406,7 +406,7 @@ default-features = true
 ## test experimental
 
 [workspace.dependencies.test_experimental_a]
-version = "~0.2.0"
+version = "~0.3.0"
 path = "module/test/a"
 default-features = true
 

--- a/module/move/willbe/src/tools/graph.rs
+++ b/module/move/willbe/src/tools/graph.rs
@@ -1,6 +1,8 @@
 /// Internal namespace.
 pub( crate ) mod private
 {
+  use crate::*;
+
   use std::
   {
     ops::Index,
@@ -17,6 +19,7 @@ pub( crate ) mod private
   use petgraph::prelude::*;
 
   use error_tools::for_lib::Error;
+  use package::{ Package, publish_need };
 
   #[ derive( Debug, Error ) ]
   pub enum GraphError< T : Debug >
@@ -153,6 +156,65 @@ pub( crate ) mod private
 
     subgraph
   }
+
+  /// Removes nodes that are not required to be published from the graph.
+  ///
+  /// # Arguments
+  ///
+  /// * `package_map` - A reference to a `HashMap` mapping `String` keys to `Package` values.
+  /// * `graph` - A reference to a `Graph` of nodes and edges, where nodes are of type `String` and edges are of type `String`.
+  /// * `roots` - A slice of `String` representing the root nodes of the graph.
+  ///
+  /// # Returns
+  ///
+  /// A new `Graph` with the nodes that are not required to be published removed.
+  pub fn remove_not_required_to_publish( package_map : &HashMap< String, Package >, graph : &Graph< String, String >, roots : &[ String ] ) -> Graph< String, String >
+  {
+    let mut nodes = HashSet::new();
+    let mut cleared_graph = Graph::new();
+
+    for root in roots
+    {
+      let root = graph.node_indices().find( | &i | graph[ i ] == *root ).unwrap();
+      let mut dfs = DfsPostOrder::new( &graph, root );
+      'main : while let Some( n ) = dfs.next(&graph)
+      {
+        for neighbor in graph.neighbors_directed( n, Outgoing )
+        {
+          if nodes.contains( &neighbor )
+          {
+            nodes.insert( n );
+            continue 'main;
+          }
+        }
+        let package = package_map.get( &graph[ n ] ).unwrap();
+        _ = cargo::package( package.crate_dir(), false ).unwrap();
+        if publish_need( package ).unwrap()
+        {
+          nodes.insert( n );
+        }
+      }
+    }
+    let mut new_map = HashMap::new();
+    for node in nodes.iter().copied() { new_map.insert( node, cleared_graph.add_node( graph[ node ].clone() ) ); }
+
+    for sub_node_id in nodes
+    {
+      for edge in graph.edges( sub_node_id )
+      {
+        match ( new_map.get( &edge.source() ), new_map.get( &edge.target() ) )
+        {
+          ( Some( &from ), Some( &to ) ) =>
+          {
+            cleared_graph.add_edge( from, to, graph[ edge.id() ].clone() );
+          }
+          _ => {}
+        }
+      }
+    }
+
+    cleared_graph
+  }
 }
 
 //
@@ -162,4 +224,5 @@ crate::mod_interface!
   protected use construct;
   protected use toposort;
   protected use subgraph;
+  protected use remove_not_required_to_publish;
 }

--- a/module/test/a/Cargo.toml
+++ b/module/test/a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_experimental_a"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = """

--- a/module/test/a/src/lib.rs
+++ b/module/test/a/src/lib.rs
@@ -8,6 +8,7 @@ mod tests
 {
   use super::*;
 
+
   #[ test ]
   fn it_works()
   {


### PR DESCRIPTION
The principal update included in this commit is the modification to our package publishing mechanism. The solution will no longer publish packages indiscriminately. Instead, it is now confined to publishing packages up to a chosen threshold. This optimal plan prevents the publication of inessential or superfluous packages, favoring more necessary ones.

The prior logic was detailed in pull request #1155. There's a variation in the third step of the process: Now, `E` have affected `C` and `B`. Previously, `E` could have affected `C`, `B`, and `A`.