### PR TITLE
READY: (willbe): Update cargo::package call to use 'dry' parameter

### DIFF
--- a/module/move/willbe/src/package.rs
+++ b/module/move/willbe/src/package.rs
@@ -405,7 +405,7 @@ mod private
 
     let package_dir = &package.crate_dir();
 
-    let output = cargo::package( &package_dir, false ).context( "Take information about package" ).map_err( | e | ( report.clone(), e ) )?;
+    let output = cargo::package( &package_dir, dry ).context( "Take information about package" ).map_err( | e | ( report.clone(), e ) )?;
     if output.err.contains( "not yet committed")
     {
       return Err(( report, format_err!( "Some changes wasn't committed. Please, commit or stash that changes and try again." ) ));


### PR DESCRIPTION
This commit fixes the error where the 'dry' parameter was not being used in the call to cargo::package. Previously, it was hardcoded to use 'false' for every invocation. Now it correctly bases the decision on the actual value of 'dry'.