### PR TITLE
NOT READY(willbe): Small fixes

### DIFF
--- a/module/move/willbe/src/test.rs
+++ b/module/move/willbe/src/test.rs
@@ -61,6 +61,8 @@ mod private
   {
     fn fmt( &self, f : &mut Formatter< '_ > ) -> std::fmt::Result
     {
+      let mut failed = 0;
+      let mut success = 0;
       writeln!( f, "The tests will be executed using the following configurations:" )?;
       for ( channel, feature ) in self.tests.iter().sorted_by( | a, b | a.0.cmp( b.0 ) ).flat_map( | ( c, f ) | f.iter().map( |( f, _ )| ( *c, f ) ) )
       {
@@ -80,34 +82,41 @@ mod private
           if self.dry
           {
             let feature = if feature.is_empty() { "no-features" } else { feature };
+            success += 1;
             writeln!( f, "[{channel} | {feature}]: `{}`", result.command )?
           }
           else
           {
             // if tests failed or if build failed
-            match ( result.out.contains( "failures" ), result.err.contains( "error" ) ) 
-            { 
-              ( true, _ ) => 
+            match ( result.out.contains( "failures" ), result.err.contains( "error" ) )
+            {
+              ( true, _ ) =>
               {
                 let mut out = result.out.replace( "\n", "\n      " );
                 out.push_str( "\n" );
+                failed += 1;
                 write!( f, "  [ {} | {} ]: ❌ failed\n  \n{out}", channel, feature )?;
               }
               ( _, true ) =>
               {
                 let mut err = result.err.replace("\n", "\n      " );
                 err.push_str( "\n" );
+                failed += 1;
                 write!(f, "  [ {} | {} ]: ❌ failed\n  \n{err}", channel, feature )?;
               }
               ( false, false ) =>
               {
                 let feature = if feature.is_empty() { "no-features" } else { feature };
+                success += 1;
                 writeln!( f, "  [ {} | {} ]: ✅ successful", channel, feature )?;
               }
             }
           }
         }
       }
+      writeln!( f, "\n=== Module report ===" )?;
+      writeln!( f, "✅ Number of successfully passed test variants : {success}" )?;
+      writeln!( f, "❌ Number of failed test variants : {failed}" )?;
 
       Ok( () )
     }
@@ -159,6 +168,9 @@ mod private
           writeln!( f, "{}", report )?;
         }
       }
+      writeln!( f, "==== Global report ====" )?;
+      writeln!( f, "✅ Number of successfully passed modules : {}", self.succses_reports.len() )?;
+      writeln!( f, "❌ Number of failed modules : {}", self.failure_reports.len() )?;
       if !self.dry
       {
         writeln!( f, "You can execute the command with the dry-run:0." )?;

--- a/module/move/willbe/src/test.rs
+++ b/module/move/willbe/src/test.rs
@@ -95,28 +95,28 @@ mod private
                 let mut out = result.out.replace( "\n", "\n      " );
                 out.push_str( "\n" );
                 failed += 1;
-                write!( f, "  [ {} | {} ]: ❌ failed\n  \n{out}", channel, feature )?;
+                write!( f, "  [ {} | {} ]: ❌  failed\n  \n{out}", channel, feature )?;
               }
               ( _, true ) =>
               {
                 let mut err = result.err.replace("\n", "\n      " );
                 err.push_str( "\n" );
                 failed += 1;
-                write!(f, "  [ {} | {} ]: ❌ failed\n  \n{err}", channel, feature )?;
+                write!(f, "  [ {} | {} ]: ❌  failed\n  \n{err}", channel, feature )?;
               }
               ( false, false ) =>
               {
                 let feature = if feature.is_empty() { "no-features" } else { feature };
                 success += 1;
-                writeln!( f, "  [ {} | {} ]: ✅ successful", channel, feature )?;
+                writeln!( f, "  [ {} | {} ]: ✅  successful", channel, feature )?;
               }
             }
           }
         }
       }
-      writeln!( f, "\n=== Module report ===" )?;
-      writeln!( f, "✅ Number of successfully passed test variants : {success}" )?;
-      writeln!( f, "❌ Number of failed test variants : {failed}" )?;
+      writeln!( f, "\nModule report" )?;
+      writeln!( f, "  ✅  Number of successfully passed test variants : {success}" )?;
+      writeln!( f, "  ❌  Number of failed test variants : {failed}" )?;
 
       Ok( () )
     }
@@ -168,9 +168,9 @@ mod private
           writeln!( f, "{}", report )?;
         }
       }
-      writeln!( f, "==== Global report ====" )?;
-      writeln!( f, "✅ Number of successfully passed modules : {}", self.succses_reports.len() )?;
-      writeln!( f, "❌ Number of failed modules : {}", self.failure_reports.len() )?;
+      writeln!( f, "Global report" )?;
+      writeln!( f, "  ✅  Number of successfully passed modules : {}", self.succses_reports.len() )?;
+      writeln!( f, "  ❌  Number of failed modules : {}", self.failure_reports.len() )?;
       if !self.dry
       {
         writeln!( f, "You can execute the command with the dry-run:0." )?;


### PR DESCRIPTION
Now if there is a compilation error, only it is output (`std::err`), and if tests fail, only their output (`std::out`). And also other small changes.