### PR TITLE
NOT READY(wca): Add command creation to CommandsAggregator

### DIFF
--- a/module/move/wca/src/ca/grammar/command.rs
+++ b/module/move/wca/src/ca/grammar/command.rs
@@ -1,6 +1,6 @@
 pub( crate ) mod private
 {
-  use crate::Type;
+  use crate::{ Routine, Type };
 
   use std::collections::HashMap;
   use former::Former;
@@ -64,6 +64,11 @@ pub( crate ) mod private
     // Aliased key -> Original key
     pub properties_aliases : HashMap< String, String >,
     // qqq : for Bohdan : routine should also be here
+    // aaa : here it is
+    // qqq : make it usable and remove default(?)
+    /// The type `Routine` represents the specific implementation of the routine.
+    #[ default( Routine::new( | _ | Ok( () ) ) ) ]
+    pub routine : Routine,
   }
 
   impl CommandFormer

--- a/module/move/wca/tests/inc/commands_aggregator/basic.rs
+++ b/module/move/wca/tests/inc/commands_aggregator/basic.rs
@@ -40,6 +40,34 @@ tests_impls!
     a_true!( ca.perform( ".help.help.help" ).is_err() );
   }
 
+  fn with_custom_sub_former()
+  {
+    let ca = CommandsAggregator::former()
+    .command( "command" )
+      .hint( "hint" )
+      .long_hint( "long_hint" )
+      .routine( Routine::new( | _ | { println!( "Command" ); Ok( () ) } ) )
+      .end()
+    .command( "command2" )
+      .hint( "hint" )
+      .long_hint( "long_hint" )
+      .routine( Routine::new( | _ | { println!( "Command2" ); Ok( () ) } ) )
+      .end()
+    .build();
+
+    a_id!( (), ca.perform( ".command2 .help" ).unwrap() ); // raw string -> GrammarProgram -> ExecutableProgram -> execute
+
+    a_id!( (), ca.perform( ".help command" ).unwrap() );
+    a_id!( (), ca.perform( ".help command2" ).unwrap() );
+    a_id!( (), ca.perform( ".help help" ).unwrap() );
+
+    a_id!( (), ca.perform( ".help.command" ).unwrap() );
+    a_id!( (), ca.perform( ".help.command2" ).unwrap() );
+    a_id!( (), ca.perform( ".help.help" ).unwrap() );
+
+    a_true!( ca.perform( ".help.help.help" ).is_err() );
+  }
+
   fn with_only_general_help()
   {
     let ca = CommandsAggregator::former()
@@ -387,6 +415,7 @@ tests_impls!
 tests_index!
 {
   simple,
+  with_custom_sub_former,
   with_only_general_help,
   custom_converters,
   custom_parser,


### PR DESCRIPTION
The `CommandsAggregatorFormer` now supports the creation of commands with associated routines. This allows for much greater flexibility and ease in setting up new commands. Additionally, a test has been added to ensure the correct functioning of this new feature.