### PR TITLE
READY(willbe/`.test`):Enabled feature fix

### DIFF
--- a/module/move/willbe/src/command/test.rs
+++ b/module/move/willbe/src/command/test.rs
@@ -125,7 +125,7 @@ mod private
       this = if let Some( v ) = value.get_owned( "exclude" ) { this.exclude::< Vec< String > >( v ) } else { this };
       this = if let Some( v ) = value.get_owned( "with_debug" ) { this.dry::< bool >( v ) } else { this };
       this = if let Some( v ) = value.get_owned( "with_release" ) { this.dry::< bool >( v ) } else { this };
-      this = if let Some( v ) = value.get_owned( "enabled" ) { this.exclude::< Vec< String > >( v ) } else { this };
+      this = if let Some( v ) = value.get_owned( "enabled_features" ) { this.enabled_features::< Vec< String > >( v ) } else { this };
 
       Ok( this.form() )
     }


### PR DESCRIPTION
Now the `enabled_features` property is working (all the features of the chalk listed in this property will be added to combinations, as described below).
# Before:
![image](https://github.com/Wandalen/wTools/assets/56289352/6da1b5b9-9406-49ad-87d7-1400d1cf6819)
# After:
![image](https://github.com/Wandalen/wTools/assets/56289352/baebf6c3-6be5-4789-99fd-3140d0ee4a7b)
