### PR TITLE
READY : (willbe): Save remote version of the package on `publish.diff`

### DIFF
--- a/module/move/willbe/src/action/publish_diff.rs
+++ b/module/move/willbe/src/action/publish_diff.rs
@@ -10,11 +10,19 @@ mod private
   use wtools::error::for_app::Result;
   use diff::{ DiffReport, crate_diff };
 
+  /// Options for `publish_diff` command
+  #[ derive( Debug, former::Former ) ]
+  pub struct PublishDiffOptions
+  {
+    path : PathBuf,
+    keep_archive : Option< PathBuf >,
+  }
+
   /// Return the differences between a local and remote package versions.
   #[ cfg_attr( feature = "tracing", tracing::instrument ) ]
-  pub fn publish_diff( path : PathBuf ) -> Result< DiffReport >
+  pub fn publish_diff( o : PublishDiffOptions ) -> Result< DiffReport >
   {
-    let path = AbsolutePath::try_from( path )?;
+    let path = AbsolutePath::try_from( o.path )?;
     let dir = CrateDir::try_from( path )?;
 
     let package = package::Package::try_from( dir.clone() )?;
@@ -25,6 +33,21 @@ mod private
     let l = CrateArchive::read( packed_crate::local_path( name, version, dir )? )?;
     let r = CrateArchive::download_crates_io( name, version ).unwrap();
 
+    if let Some( out_path ) = o.keep_archive
+    {
+      _ = std::fs::create_dir_all( &out_path );
+      for path in r.list()
+      {
+        let local_path = out_path.join( path );
+        let folder = local_path.parent().unwrap();
+        _ = std::fs::create_dir_all( folder );
+
+        let content = r.content_bytes( path ).unwrap();
+
+        std::fs::write( local_path, content )?;
+      }
+    }
+
     Ok( crate_diff( &l, &r ) )
   }
 }
@@ -33,6 +56,7 @@ mod private
 
 crate::mod_interface!
 {
+  orphan use PublishDiffOptions;
   /// Publishes the difference between the local and published versions of a package.
   orphan use publish_diff;
 }

--- a/module/move/willbe/src/command/mod.rs
+++ b/module/move/willbe/src/command/mod.rs
@@ -42,6 +42,11 @@ pub( crate ) mod private
         .kind( Type::Path )
         .optional( true )
         .end()
+      .property( "keep_archive" )
+        .hint( "Save remote package version to the specified path" )
+        .kind( Type::Path )
+        .optional( true )
+        .end()
       .routine( command::publish_diff )
       .end()
 


### PR DESCRIPTION
I don't know how to get the target directory at runtime.
The `CARGO_TARGET_DIR` environment variable does not exist at runtime.