### PR TITLE
READY: (willbe): Move ignore list constant to diff module

### DIFF
--- a/module/move/willbe/src/action/publish_diff.rs
+++ b/module/move/willbe/src/action/publish_diff.rs
@@ -22,12 +22,6 @@ mod private
   #[ cfg_attr( feature = "tracing", tracing::instrument ) ]
   pub fn publish_diff( o : PublishDiffOptions ) -> Result< DiffReport >
   {
-    // These files are ignored because they can be safely changed without affecting functionality
-    //
-    // - `.cargo_vcs_info.json` - contains the git sha1 hash that varies between different commits
-    // - `Cargo.toml.orig` - can be safely modified because it is used to generate the `Cargo.toml` file automatically, and the `Cargo.toml` file is sufficient to check for changes
-    const IGNORE_LIST : [ &str; 2 ] = [ ".cargo_vcs_info.json", "Cargo.toml.orig" ];
-
     let path = AbsolutePath::try_from( o.path )?;
     let dir = CrateDir::try_from( path )?;
 
@@ -54,7 +48,7 @@ mod private
       }
     }
 
-    Ok( crate_diff( &l, &r ).exclude( IGNORE_LIST ) )
+    Ok( crate_diff( &l, &r ).exclude( diff::PUBLISH_IGNORE_LIST ) )
   }
 }
 

--- a/module/move/willbe/src/entity/diff.rs
+++ b/module/move/willbe/src/entity/diff.rs
@@ -14,6 +14,12 @@ mod private
   use similar::*;
 
   use wtools::iter::Itertools;
+  
+  /// These files are ignored because they can be safely changed without affecting functionality
+  ///
+  /// - `.cargo_vcs_info.json` - contains the git sha1 hash that varies between different commits
+  /// - `Cargo.toml` - can be safely modified because it is used to generate the `Cargo.toml` file automatically, and the `Cargo.toml` file is sufficient to check for changes
+  pub const PUBLISH_IGNORE_LIST : [ &str; 2 ] = [ ".cargo_vcs_info.json", "Cargo.toml" ];
 
 
   /// The `Diff` enum is designed to represent differences between two versions
@@ -215,4 +221,5 @@ crate::mod_interface!
   protected use DiffItem;
   protected use DiffReport;
   protected use crate_diff;
+  protected use PUBLISH_IGNORE_LIST;
 }

--- a/module/move/willbe/src/entity/package.rs
+++ b/module/move/willbe/src/entity/package.rs
@@ -880,12 +880,6 @@ mod private
 
   pub fn publish_need( package : &Package, path : Option< PathBuf > ) -> Result< bool, PackageError >
   {
-    // These files are ignored because they can be safely changed without affecting functionality
-    //
-    // - `.cargo_vcs_info.json` - contains the git sha1 hash that varies between different commits
-    // - `Cargo.toml.orig` - can be safely modified because it is used to generate the `Cargo.toml` file automatically, and the `Cargo.toml` file is sufficient to check for changes
-    const IGNORE_LIST : [ &str; 2 ] = [ ".cargo_vcs_info.json", "Cargo.toml" ];
-
     let name = package.name()?;
     let version = package.version()?;
     let local_package_path = path
@@ -903,7 +897,7 @@ mod private
       _ => return Err( PackageError::LoadRemotePackage ),
     };
 
-    Ok( crate_diff( &local_package, &remote_package ).exclude( IGNORE_LIST ).has_changes() )
+    Ok( crate_diff( &local_package, &remote_package ).exclude( diff::PUBLISH_IGNORE_LIST ).has_changes() )
   }
 }
 


### PR DESCRIPTION
The constant `IGNORE_LIST`, containing file names that are safe to be changed without affecting functionality, has been moved from `publish_diff.rs` and `package.rs` to `diff.rs`. This centralizes tracking of ignored files in our code and simplifies iterations across other modules. Now, `publish_diff` and `package` reference this constant from `diff.rs`, enhancing code readability and maintenance.