### PR TITLE
READY: (wca): Refactor help command handling and clean up tests

### DIFF
--- a/module/move/wca/src/ca/executor/executor.rs
+++ b/module/move/wca/src/ca/executor/executor.rs
@@ -4,7 +4,7 @@ pub( crate ) mod private
 
   use wtools::error::Result;
   use error_tools::return_err;
-  use ca::help::private::{ HelpGeneratorArgs, LevelOfDetail, generate_help_content };
+  use ca::help::private::{ HelpGeneratorOptions, LevelOfDetail, generate_help_content };
 
   // aaa : for Bohdan : how is it useful? where is it used?
   // aaa : `ExecutorType` has been removed
@@ -90,7 +90,7 @@ pub( crate ) mod private
     {
       "." =>
       {
-        let generator_args = HelpGeneratorArgs::former()
+        let generator_args = HelpGeneratorOptions::former()
         .command_prefix( "." )
         .form();
         
@@ -99,7 +99,7 @@ pub( crate ) mod private
       }
       ".?" =>
       {
-        let generator_args = HelpGeneratorArgs::former()
+        let generator_args = HelpGeneratorOptions::former()
         .description_detailing( LevelOfDetail::Simple )
         .subject_detailing( LevelOfDetail::Simple )
         .property_detailing( LevelOfDetail::Simple )
@@ -116,7 +116,7 @@ pub( crate ) mod private
         {
           return_err!( "Not found command that starts with `.{}`.", name );
         }
-        let generator_args = HelpGeneratorArgs::former()
+        let generator_args = HelpGeneratorOptions::former()
         .command_prefix( "." )
         .for_commands( commands )
         .form();
@@ -130,7 +130,7 @@ pub( crate ) mod private
         let command = dictionary.command( &name.strip_prefix( '.' ).unwrap_or( name ).to_string() );
         if let Some( command ) = command
         {
-          let generator_args = HelpGeneratorArgs::former()
+          let generator_args = HelpGeneratorOptions::former()
           .for_commands([ command ])
           .description_detailing( LevelOfDetail::Detailed )
           .subject_detailing( LevelOfDetail::Simple )

--- a/module/move/wca/src/ca/help.rs
+++ b/module/move/wca/src/ca/help.rs
@@ -56,7 +56,7 @@ pub( crate ) mod private
   }
 
   // qqq : for Barsik : make possible to change properties order
-  fn generate_help_content( dictionary : &Dictionary, o : HelpGeneratorOptions< '_ > ) -> String
+  pub( crate ) fn generate_help_content( dictionary : &Dictionary, o : HelpGeneratorOptions< '_ > ) -> String
   {
     struct Row
     {
@@ -93,8 +93,7 @@ pub( crate ) mod private
         LevelOfDetail::Detailed => command.properties.iter().map( |( n, v )| format!( "< {n}:{}{:?} >", if v.optional { "?" } else { "" }, v.kind ) ).collect::< Vec< _ > >().join( " " ),
       };
 
-      // we can not format table with footers for each command
-      let footer = if o.with_footer && o.for_command.is_some()
+      let footer = if o.with_footer
       {
         let full_subjects = command.subjects.iter().map( | subj | format!( "- {} [{}{:?}]", subj.hint, if subj.optional { "?" } else { "" }, subj.kind ) ).join( "\n\t" );
         let full_properties = format_table( command.properties.iter().sorted_by_key( |( name, _ )| *name ).map( |( name, value )| [ name.clone(), format!( "- {} [{}{:?}]", value.hint, if value.optional { "?" } else { "" }, value.kind ) ] ) ).unwrap().replace( '\n', "\n\t" );
@@ -410,6 +409,5 @@ crate::mod_interface!
 {
   protected use HelpGeneratorFn;
   protected use HelpGeneratorOptions;
-  protected use dot_command;
   prelude use HelpVariants;
 }

--- a/module/move/wca/src/ca/tool/table.rs
+++ b/module/move/wca/src/ca/tool/table.rs
@@ -109,8 +109,10 @@ mod private
         formatted_table.push_str( &format!( "{:width$}", cell, width = max_lengths[ i ] ) );
         formatted_table.push( ' ' );
       }
+      formatted_table.pop(); // trailing space
       formatted_table.push( '\n' );
     }
+    formatted_table.pop(); // trailing end of line
     
     Ok( formatted_table )
   }

--- a/module/move/wca/tests/inc/commands_aggregator/basic.rs
+++ b/module/move/wca/tests/inc/commands_aggregator/basic.rs
@@ -71,8 +71,6 @@ tests_impls!
     a_id!( (), ca.perform( "." ).unwrap() );
     // qqq : this use case is disabled
     // a_id!( (), ca.perform( ".cmd." ).unwrap() );
-
-    a_true!( ca.perform( ".c." ).is_err() );
   }
 
   fn error_types()

--- a/module/move/wca/tests/inc/commands_aggregator/help.rs
+++ b/module/move/wca/tests/inc/commands_aggregator/help.rs
@@ -53,7 +53,7 @@ wca = {{path = "{}"}}"#,
 
   assert_eq!
   (
-    "Help command\n\necho < subjects > < properties > - prints all subjects and properties\n\nSubjects:\n\t- Subject [?String]\nProperties:\n\tproperty - simple property [?String]\n",
+    "Help command\n\n.echo < subjects > < properties > - prints all subjects and properties\n\nSubjects:\n\t- Subject [?String]\nProperties:\n\tproperty - simple property [?String]\n",
     result
   );
 }

--- a/module/move/wca/tests/inc/parser/command.rs
+++ b/module/move/wca/tests/inc/parser/command.rs
@@ -398,9 +398,9 @@ tests_impls!
     (
       ParsedCommand
       {
-        name : "".into(),
+        name : ".".into(),
         subjects : vec![],
-        properties : HashMap::from_iter([( "command_prefix".into(), ".".into() ) ]),
+        properties : HashMap::new(),
       },
       parser.command( "." ).unwrap()
     );
@@ -410,23 +410,11 @@ tests_impls!
     (
       ParsedCommand
       {
-        name : "".into(),
-        subjects : vec![ "command.".into() ],
-        properties : HashMap::from_iter([( "command_prefix".into(), ".".into() ) ]),
+        name : "command.".into(),
+        subjects : vec![],
+        properties : HashMap::new(),
       },
       parser.command( ".command." ).unwrap()
-    );
-
-    // command . with subjects
-    a_id!
-    (
-      ParsedCommand
-      {
-        name : "".into(),
-        subjects : vec![ "command.".into() ],
-        properties : HashMap::from_iter([( "command_prefix".into(), ".".into() ) ]),
-      },
-      parser.command( ".command. <this will be ignored>" ).unwrap()
     );
   }
 }


### PR DESCRIPTION
Renamed HelpGeneratorArgs to HelpGeneratorOptions and made generate_help_content function more accessible for internal crate use. Adjusted how command is parsed within the help and executor modules, notably by handling command prefixes differently. Made minor changes to table formatting for better output and removed unnecessary test cases in command.rs.