### PR TITLE
READY: (willbe): Improve error handling and reporting in modules

### DIFF
--- a/module/move/willbe/src/action/publish.rs
+++ b/module/move/willbe/src/action/publish.rs
@@ -137,7 +137,7 @@ mod private
       None
     };
 
-    let subgraph = graph::remove_not_required_to_publish( &package_map, &tmp, &packages_to_publish, dir.clone() );
+    let subgraph = graph::remove_not_required_to_publish( &package_map, &tmp, &packages_to_publish, dir.clone() ).err_with( || report.clone() )?;
     let subgraph = subgraph.map( | _, n | n, | _, e | e );
 
     let queue = graph::toposort( subgraph ).unwrap().into_iter().map( | n | package_map.get( &n ).unwrap() ).cloned().collect::< Vec< _ > >();

--- a/module/move/willbe/src/tool/graph.rs
+++ b/module/move/willbe/src/tool/graph.rs
@@ -21,6 +21,7 @@ pub( crate ) mod private
   use petgraph::prelude::*;
 
   use error_tools::for_lib::Error;
+  use error::Result;
   use package::{ Package, publish_need };
 
   #[ derive( Debug, Error ) ]
@@ -242,7 +243,7 @@ pub( crate ) mod private
     roots : &[ String ], 
     temp_path : Option< PathBuf >,
   ) 
-  -> Graph< String, String >
+  -> Result< Graph< String, String > >
   {
     let mut nodes = HashSet::new();
     let mut cleared_graph = Graph::new();
@@ -269,7 +270,7 @@ pub( crate ) mod private
           .option_temp_path( temp_path.clone() )
           .dry( false )
           .form()
-        ).unwrap();
+        )?;
         if publish_need( package, temp_path.clone() ).unwrap()
         {
           nodes.insert( n );
@@ -294,7 +295,7 @@ pub( crate ) mod private
       }
     }
 
-    cleared_graph
+    Ok( cleared_graph )
   }
 }
 


### PR DESCRIPTION
This commit improves error handling and reporting in 'publish.rs', 'package.rs' and 'graph.rs' modules. Specifically, error fallbacks and more descriptive error messages have been introduced. In addition, the 'perform_package_publish' function now returns a tuple containing both a 'PublishReport' and an 'Error', rather than just a 'PublishReport'.

## Before
![before](https://i.imgur.com/bgfPUUQ.png)

## After
![after](https://i.imgur.com/Mx7np35.png)