### PR TITLE
READY: (willbe): Refactor publish action to be able to display the publication plan before execution

### DIFF
--- a/module/move/willbe/src/entity/package.rs
+++ b/module/move/willbe/src/entity/package.rs
@@ -471,6 +471,9 @@ mod private
     #[ default( true ) ]
     pub dry : bool,
 
+    /// Required for tree view only
+    pub roots : Vec< CrateDir >,
+
     /// `plans` - This is a vector containing the instructions for publishing each package. Each item
     /// in the `plans` vector indicates a `PackagePublishInstruction` set for a single package. It outlines
     /// how to build and where to publish the package amongst other instructions. The `#[setter( false )]`
@@ -487,19 +490,18 @@ mod private
     /// # Arguments
     ///
     /// * `f` - A mutable reference to a `Formatter` used for writing the output.
-    /// * `roots` - A slice of `CrateDir` representing the root crates to display.
     ///
     /// # Errors
     ///
     /// Returns a `std::fmt::Error` if there is an error writing to the formatter.
-    pub fn display_as_tree( &self, f : &mut Formatter< '_ >, roots : &[ CrateDir ] ) -> std::fmt::Result
+    pub fn display_as_tree( &self, f : &mut Formatter< '_ > ) -> std::fmt::Result
     {
       let name_bump_report = self
       .plans
       .iter()
       .map( | x | ( &x.package_name, ( x.version_bump.old_version.to_string(), x.version_bump.new_version.to_string() ) ) )
       .collect::< HashMap< _, _ > >();
-      for wanted in roots
+      for wanted in &self.roots
       {
         let list = action::list
         (

--- a/module/move/willbe/src/entity/package.rs
+++ b/module/move/willbe/src/entity/package.rs
@@ -494,7 +494,9 @@ mod private
     /// # Errors
     ///
     /// Returns a `std::fmt::Error` if there is an error writing to the formatter.
-    pub fn display_as_tree( &self, f : &mut Formatter< '_ > ) -> std::fmt::Result
+    pub fn write_as_tree< W >( &self, f : &mut W ) -> std::fmt::Result
+    where
+      W : std::fmt::Write
     {
       let name_bump_report = self
       .plans
@@ -545,7 +547,9 @@ mod private
     /// # Errors
     ///
     /// Returns a `std::fmt::Error` if there is an error writing to the formatter.
-    pub fn display_as_list( &self, f : &mut Formatter< '_ > ) -> std::fmt::Result
+    pub fn write_as_list< W >( &self, f : &mut W ) -> std::fmt::Result
+    where
+      W : std::fmt::Write
     {
       for ( idx, package ) in self.plans.iter().enumerate()
       {


### PR DESCRIPTION
The publish action has been modified to be handle via a publication plan. This adds an intermediary step where the publication steps are defined first in a plan before execution. This change also removed the 'wanted_to_publish' attribute from the PublishReport struct. Displaying as a tree is now also based on roots within the plan.