### PR TITLE
READY: (willbe): Add duplicate flag and restructure dependency reporting

### DIFF
--- a/module/move/willbe/src/action/list.rs
+++ b/module/move/willbe/src/action/list.rs
@@ -442,7 +442,7 @@ mod private
           tree_package_report( package.manifest_path().as_std_path().try_into().unwrap(), &mut report, &mut visited )
         }
         let ListReport::Tree( tree ) = report else { unreachable!() };
-        let tree = rearrange_duplicates( merge_dev_dependencies( tree ) );
+        let tree = merge_dev_dependencies( tree );
         report = ListReport::Tree( tree );
       }
       ListFormat::Topological =>
@@ -558,7 +558,7 @@ mod private
 
     Ok( report )
   }
-  
+
   fn merge_dev_dependencies( mut report: Vec< ListNodeReport > ) -> Vec< ListNodeReport >
   {
     let mut dev_dependencies = vec![];
@@ -570,10 +570,10 @@ mod private
     {
       last_report.dev_dependencies = dev_dependencies;
     }
-    
+
     report
   }
-  
+
   fn merge_dev_dependencies_impl( report : &mut ListNodeReport, mut dev_deps_acc : Vec< ListNodeReport > ) -> Vec< ListNodeReport >
   {
     for dep in report.normal_dependencies.iter_mut()
@@ -582,7 +582,7 @@ mod private
     {
       dev_deps_acc = merge_dev_dependencies_impl( dep, dev_deps_acc );
     }
-    
+
     for dep in std::mem::take( &mut report.dev_dependencies )
     {
       if !dev_deps_acc.contains( &dep )
@@ -590,7 +590,7 @@ mod private
         dev_deps_acc.push( dep );
       }
     }
-    
+
     dev_deps_acc
   }
   
@@ -620,7 +620,7 @@ mod private
       rearrange_duplicates_resolver( &mut node.normal_dependencies, required );
       rearrange_duplicates_resolver( &mut node.dev_dependencies, required );
       rearrange_duplicates_resolver( &mut node.build_dependencies, required );
-      
+
       if !node.duplicate
       {
         if let Some( r ) = required.iter_mut().flat_map( |( _, v )| v )


### PR DESCRIPTION
A 'duplicate' flag was added to the 'ListNodeReport' struct to indicate a node is a duplicate. The process of dependency reporting was restructured with a focus to handle such duplicates more effectively. Also added new functions that merge development dependencies and rearrange duplicates to ensure correct dependency relationships are visualized in reports.

## Before:
```
wca
├─ error_tools
│  [dev-dependencies]
│  └─ test_tools
│     ├─ data_type
│     │  └─ interval_adapter
│     │     [dev-dependencies]
│     │     └─ test_tools(*)
│     │  [dev-dependencies]
│     │  └─ test_tools(*)
│     ├─ diagnostics_tools
│     │  [dev-dependencies]
│     │  └─ test_tools(*)
│     ├─ error_tools(*)
│     ├─ former
│     │  ├─ collection_tools
│     │  │  [dev-dependencies]
│     │  │  └─ test_tools(*)
│     │  └─ former_meta
│     │     ├─ iter_tools
│     │     │  [dev-dependencies]
│     │     │  └─ test_tools(*)
│     │     └─ macro_tools
│     │        └─ interval_adapter(*)
│     │        [dev-dependencies]
│     │        └─ test_tools(*)
│     │     [dev-dependencies]
│     │     ├─ former(*)
│     │     └─ test_tools(*)
│     │  [dev-dependencies]
│     │  └─ test_tools(*)
│     ├─ mem_tools
│     │  [dev-dependencies]
│     │  └─ test_tools(*)
│     ├─ meta_tools
│     │  ├─ for_each
│     │  │  [dev-dependencies]
│     │  │  └─ test_tools(*)
│     │  ├─ impls_index
│     │  │  └─ impls_index_meta
│     │  │     └─ macro_tools(*)
│     │  │  [dev-dependencies]
│     │  │  └─ test_tools(*)
│     │  └─ mod_interface
│     │     └─ mod_interface_meta
│     │        ├─ derive_tools
│     │        │  ├─ clone_dyn
│     │        │  │  └─ clone_dyn_meta
│     │        │  │     └─ macro_tools(*)
│     │        │  │     [dev-dependencies]
│     │        │  │     └─ test_tools(*)
│     │        │  │  [dev-dependencies]
│     │        │  │  └─ test_tools(*)
│     │        │  ├─ derive_tools_meta
│     │        │  │  ├─ iter_tools(*)
│     │        │  │  └─ macro_tools(*)
│     │        │  │  [dev-dependencies]
│     │        │  │  └─ test_tools(*)
│     │        │  └─ variadic_from
│     │        │     └─ derive_tools_meta(*)
│     │        │     [dev-dependencies]
│     │        │     └─ test_tools(*)
│     │        │  [dev-dependencies]
│     │        │  └─ test_tools(*)
│     │        └─ macro_tools(*)
│     │        [dev-dependencies]
│     │        └─ test_tools(*)
│     │     [dev-dependencies]
│     │     └─ test_tools(*)
│     │  [dev-dependencies]
│     │  └─ test_tools(*)
│     ├─ process_tools
│     │  ├─ error_tools(*)
│     │  ├─ former(*)
│     │  ├─ iter_tools(*)
│     │  ├─ mod_interface(*)
│     │  └─ proper_path_tools
│     │     └─ mod_interface(*)
│     │     [dev-dependencies]
│     │     └─ test_tools(*)
│     │  [dev-dependencies]
│     │  └─ test_tools(*)
│     └─ typing_tools
│        ├─ implements
│        │  [dev-dependencies]
│        │  └─ test_tools(*)
│        ├─ inspect_type
│        │  [dev-dependencies]
│        │  └─ test_tools(*)
│        └─ is_slice
│           [dev-dependencies]
│           └─ test_tools(*)
│        [dev-dependencies]
│        └─ test_tools(*)
├─ former(*)
├─ iter_tools(*)
├─ mod_interface(*)
└─ strs_tools
   └─ former(*)
   [dev-dependencies]
   └─ test_tools(*)
[dev-dependencies]
└─ test_tools(*)
```

## After
```
wca
├─ error_tools
├─ strs_tools
│  └─ former(*)
├─ former
│  ├─ collection_tools
│  └─ former_meta
│     ├─ iter_tools(*)
│     └─ macro_tools
│        └─ interval_adapter(*)
├─ iter_tools
└─ mod_interface
   └─ mod_interface_meta
      ├─ derive_tools
      │  ├─ clone_dyn
      │  │  └─ clone_dyn_meta
      │  │     └─ macro_tools(*)
      │  ├─ derive_tools_meta
      │  │  ├─ iter_tools(*)
      │  │  └─ macro_tools(*)
      │  └─ variadic_from
      │     └─ derive_tools_meta(*)
      └─ macro_tools(*)
[dev-dependencies]
├─ test_tools(*)
├─ former(*)
└─ test_tools
   ├─ data_type
   │  └─ interval_adapter
   ├─ diagnostics_tools
   ├─ error_tools(*)
   ├─ former(*)
   ├─ mem_tools
   ├─ meta_tools
   │  ├─ for_each
   │  ├─ impls_index
   │  │  └─ impls_index_meta
   │  │     └─ macro_tools(*)
   │  └─ mod_interface(*)
   ├─ process_tools
   │  ├─ error_tools(*)
   │  ├─ former(*)
   │  ├─ iter_tools(*)
   │  ├─ mod_interface(*)
   │  └─ proper_path_tools
   │     └─ mod_interface(*)
   └─ typing_tools
      ├─ implements
      ├─ inspect_type
      └─ is_slice
```