### PR TITLE
READY : (former) : Use direct collection_tools path

### DIFF
--- a/module/core/former/src/collection/binary_heap.rs
+++ b/module/core/former/src/collection/binary_heap.rs
@@ -7,7 +7,7 @@
 
 use crate::*;
 #[ allow( unused ) ]
-use collection_tools::heap::BinaryHeap;
+use collection_tools::BinaryHeap;
 
 impl< E > Collection for BinaryHeap< E >
 {

--- a/module/core/former/src/collection/btree_map.rs
+++ b/module/core/former/src/collection/btree_map.rs
@@ -6,7 +6,7 @@
 //!
 
 use crate::*;
-use collection_tools::bmap::BTreeMap;
+use collection_tools::BTreeMap;
 
 impl< K, V > Collection for BTreeMap< K, V >
 where

--- a/module/core/former/src/collection/btree_set.rs
+++ b/module/core/former/src/collection/btree_set.rs
@@ -7,7 +7,7 @@
 
 use crate::*;
 #[ allow( unused ) ]
-use collection_tools::bset::BTreeSet;
+use collection_tools::BTreeSet;
 
 impl< E > Collection for BTreeSet< E >
 {

--- a/module/core/former/src/collection/hash_map.rs
+++ b/module/core/former/src/collection/hash_map.rs
@@ -6,7 +6,7 @@
 //!
 
 use crate::*;
-use collection_tools::hmap::HashMap;
+use collection_tools::HashMap;
 
 impl< K, V > Collection for HashMap< K, V >
 where

--- a/module/core/former/src/collection/hash_set.rs
+++ b/module/core/former/src/collection/hash_set.rs
@@ -1,7 +1,7 @@
 //! This module provides a builder pattern implementation (`HashSetFormer`) for `HashSet`-like collections. It is designed to extend the builder pattern, allowing for fluent and dynamic construction of sets within custom data structures.
 
 use crate::*;
-use collection_tools::hset::HashSet;
+use collection_tools::HashSet;
 
 impl< K > Collection for HashSet< K >
 where

--- a/module/core/former/src/collection/linked_list.rs
+++ b/module/core/former/src/collection/linked_list.rs
@@ -7,7 +7,7 @@
 
 use crate::*;
 #[ allow( unused ) ]
-use collection_tools::list::LinkedList;
+use collection_tools::LinkedList;
 
 impl< E > Collection for LinkedList< E >
 {

--- a/module/core/former/src/collection/vector.rs
+++ b/module/core/former/src/collection/vector.rs
@@ -7,7 +7,7 @@
 
 use crate::*;
 #[ allow( unused ) ]
-use collection_tools::vec::Vec;
+use collection_tools::Vec;
 
 impl< E > Collection for Vec< E >
 {

--- a/module/core/former/src/collection/vector_deque.rs
+++ b/module/core/former/src/collection/vector_deque.rs
@@ -7,7 +7,7 @@
 
 use crate::*;
 #[ allow( unused ) ]
-use collection_tools::vecd::VecDeque;
+use collection_tools::VecDeque;
 
 impl< E > Collection for VecDeque< E >
 {


### PR DESCRIPTION
The PR ensures that collections are available directly in `collection_tools` (`use collection_tools::<COLLECTION>` without any reexports)