### PR TITLE
READY : (collection_tools) : Add enabled directive for crate alloc

### DIFF
--- a/module/core/collection_tools/src/lib.rs
+++ b/module/core/collection_tools/src/lib.rs
@@ -4,6 +4,7 @@
 #![ doc( html_root_url = "https://docs.rs/collection_tools/latest/collection_tools/" ) ]
 #![ doc = include_str!( concat!( env!( "CARGO_MANIFEST_DIR" ), "/", "Readme.md" ) ) ]
 
+#[ cfg( feature = "enabled" ) ]
 #[ cfg( any( not( feature = "no_std" ), feature = "use_alloc" ) ) ]
 extern crate alloc;
 

--- a/module/core/former/Cargo.toml
+++ b/module/core/former/Cargo.toml
@@ -59,7 +59,7 @@ derive_from_components = [ "derive_components", "former_meta/derive_from_compone
 
 [dependencies]
 former_meta = { workspace = true }
-collection_tools = { workspace = true, features = [ "collection_constructors" ] }
+collection_tools = { workspace = true, features = [ "collection_constructors", "reexports" ] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
The PR should solve the compiler error regarding not used `alloc` crate