### PR TITLE
READY : (derive_tools) : Fix deref_mut tests

### DIFF
--- a/module/core/derive_tools/tests/inc/deref_mut/bounds_inlined.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/bounds_inlined.rs
@@ -1,10 +1,19 @@
 use core::fmt::Debug;
 
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct BoundsInlined< T : ToString, U : Debug >( T, U );
+
+impl< T : ToString, U : Debug > Deref for BoundsInlined< T, U >
+{
+  type Target = T;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/bounds_inlined.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/bounds_mixed.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/bounds_mixed.rs
@@ -1,12 +1,23 @@
 use core::fmt::Debug;
 
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct BoundsMixed< T : ToString, U >( T, U )
 where
   U : Debug;
+
+impl< T : ToString, U > Deref for BoundsMixed< T, U >
+where
+  U : Debug,
+{
+  type Target = T;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/bounds_mixed.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/bounds_where.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/bounds_where.rs
@@ -1,14 +1,26 @@
 trait Trait<'a> {}
 impl<'a> Trait<'a> for i32 {}
 
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct BoundsWhere< T, U >( T, U )
 where
   T : ToString,
   for< 'a > U : Trait< 'a >;
+
+impl< T, U > Deref for BoundsWhere< T, U >
+where
+  T : ToString,
+  for< 'a > U : Trait< 'a >
+{
+  type Target = T;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/bounds_where.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/enum_named.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/enum_named.rs
@@ -1,12 +1,24 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 enum EnumNamed
 {
   A { a : String, b : i32 },
   B { a : String, b : i32 },
+}
+
+impl Deref for EnumNamed
+{
+  type Target = String;
+  fn deref( &self ) -> &Self::Target
+  {
+    match self
+    {
+      Self::A { a : v, ..} | Self::B { a : v, .. } => v
+    }
+  }
 }
 
 include!( "./only_test/enum_named.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/enum_tuple.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/enum_tuple.rs
@@ -1,12 +1,24 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 enum EnumTuple
 {
   A( String, i32 ),
   B( String, i32 ),
+}
+
+impl Deref for EnumTuple
+{
+  type Target = String;
+  fn deref( &self ) -> &Self::Target
+  {
+    match self
+    {
+      Self::A( v, .. ) | Self::B( v, .. ) => v
+    }
+  }
 }
 
 include!( "./only_test/enum_tuple.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/generics_constants.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/generics_constants.rs
@@ -1,8 +1,17 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::{ DerefMut };
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct GenericsConstants< const N : usize >( i32 );
+
+impl< const N : usize > Deref for GenericsConstants< N >
+{
+  type Target = i32;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/generics_constants.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/generics_constants_default.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/generics_constants_default.rs
@@ -1,8 +1,17 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct GenericsConstantsDefault< const N : usize = 0 >( i32 );
+
+impl< const N : usize > Deref for GenericsConstantsDefault< N >
+{
+  type Target = i32;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/generics_constants_default.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/generics_lifetimes.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/generics_lifetimes.rs
@@ -1,8 +1,17 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct GenericsLifetimes< 'a >( &'a i32 );
+
+impl< 'a > Deref for GenericsLifetimes< 'a >
+{
+  type Target = &'a i32;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/generics_lifetimes.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/generics_types.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/generics_types.rs
@@ -1,8 +1,17 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct GenericsTypes< T >( T );
+
+impl< T > Deref for GenericsTypes< T >
+{
+  type Target = T;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/generics_types.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/generics_types_default.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/generics_types_default.rs
@@ -1,8 +1,17 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive ( Deref, DerefMut ) ]
+#[ derive ( DerefMut ) ]
 struct GenericsTypesDefault< T = i32 >( T );
+
+impl< T > Deref for GenericsTypesDefault< T >
+{
+  type Target = T;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/generics_types_default.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/name_collisions.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/name_collisions.rs
@@ -2,7 +2,7 @@
 #![ allow( unused_imports ) ]
 
 use ::core::ops::Deref;
-use derive_tools::{ Deref, DerefMut };
+use derive_tools::{ DerefMut };
 
 pub mod core {}
 pub mod std {}
@@ -13,11 +13,20 @@ pub mod FromPair {}
 pub mod FromBin {}
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct NameCollisions
 {
   a : i32,
   b : String,
+}
+
+impl Deref for NameCollisions
+{
+  type Target = i32;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.a
+  }
 }
 
 include!( "./only_test/name_collisions.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/struct_named.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/struct_named.rs
@@ -1,12 +1,21 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive( Deref, DerefMut ) ]
+#[ derive( DerefMut ) ]
 struct StructNamed
 {
   a : String,
   b : i32,
+}
+
+impl Deref for StructNamed
+{
+  type Target = String;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.a
+  }
 }
 
 include!( "./only_test/struct_named.rs" );

--- a/module/core/derive_tools/tests/inc/deref_mut/struct_tuple.rs
+++ b/module/core/derive_tools/tests/inc/deref_mut/struct_tuple.rs
@@ -1,8 +1,17 @@
-use core::ops::{ Deref };
-use derive_tools::{ Deref, DerefMut };
+use core::ops::Deref;
+use derive_tools::DerefMut;
 
 #[ allow( dead_code ) ]
-#[ derive ( Deref, DerefMut ) ]
+#[ derive ( DerefMut ) ]
 struct StructTuple( String, i32 );
+
+impl Deref for StructTuple
+{
+  type Target = String;
+  fn deref( &self ) -> &Self::Target
+  {
+    &self.0
+  }
+}
 
 include!( "./only_test/struct_tuple.rs" );

--- a/module/core/derive_tools_meta/src/derive/deref_mut.rs
+++ b/module/core/derive_tools_meta/src/derive/deref_mut.rs
@@ -99,9 +99,18 @@ fn generate_struct
 ///
 /// ## Input
 /// ```rust
-/// # use derive_tools_meta::{ Deref, DerefMut };
-/// #[ derive( Deref, DerefMut ) ]
+/// # use derive_tools_meta::DerefMut;
+/// #[ derive( DerefMut ) ]
 /// pub struct Struct( i32, Vec< String > );
+///
+/// impl ::core::ops::Deref for Struct
+/// {
+///   type Target = i32;
+///   fn deref( &self ) -> &Self::Target
+///   {
+///     &self.0
+///   }
+/// }
 /// ```
 ///
 /// ## Output
@@ -162,12 +171,21 @@ fn generate_struct_tuple_fields
 ///
 /// ## Input
 /// ```rust
-/// # use derive_tools_meta::{ Deref, DerefMut };
-/// #[ derive( Deref, DerefMut ) ]
+/// # use derive_tools_meta::DerefMut;
+/// #[ derive( DerefMut ) ]
 /// pub struct Struct
 /// {
 ///   a : i32,
 ///   b : Vec< String >,
+/// }
+///
+/// impl ::core::ops::Deref for Struct
+/// {
+///   type Target = i32;
+///   fn deref( &self ) -> &Self::Target
+///   {
+///     &self.a
+///   }
 /// }
 /// ```
 ///
@@ -289,13 +307,25 @@ fn generate_enum
 ///
 /// ## Input
 /// ```rust
-/// # use derive_tools_meta::{ Deref, DerefMut };
-/// #[ derive( Deref, DerefMut ) ]
+/// # use derive_tools_meta::DerefMut;
+/// #[ derive( DerefMut ) ]
 /// pub enum E
 /// {
 ///   A ( i32, Vec< String > ),
 ///   B ( i32, Vec< String > ),
 ///   C ( i32, Vec< String > ),
+/// }
+///
+/// impl ::core::ops::Deref for E
+/// {
+///   type Target = i32;
+///   fn deref( &self ) -> &Self::Target
+///   {
+///     match self
+///     {
+///       E::A( v, .. ) | E::B( v, .. ) | E::C( v, .. ) => v,
+///     }
+///   }
 /// }
 /// ```
 ///
@@ -372,13 +402,25 @@ fn generate_enum_tuple_variants
 ///
 /// ## Input
 /// ```rust
-/// # use derive_tools_meta::{ Deref, DerefMut };
-/// #[ derive( Deref, DerefMut ) ]
+/// # use derive_tools_meta::DerefMut;
+/// #[ derive( DerefMut ) ]
 /// pub enum E
 /// {
 ///   A { a : i32, b : Vec< String > },
 ///   B { a : i32, b : Vec< String > },
 ///   C { a : i32, b : Vec< String > },
+/// }
+///
+/// impl ::core::ops::Deref for E
+/// {
+///   type Target = i32;
+///   fn deref( &self ) -> &Self::Target
+///   {
+///     match self
+///     {
+///       E::A { a : v, .. } | E::B { a : v, .. } | E::C { a : v, .. } => v,
+///     }
+///   }
 /// }
 /// ```
 ///

--- a/module/core/derive_tools_meta/src/lib.rs
+++ b/module/core/derive_tools_meta/src/lib.rs
@@ -282,16 +282,11 @@ pub fn deref( input : proc_macro::TokenStream ) -> proc_macro::TokenStream
 /// Write this
 ///
 /// ```rust
-/// # use derive_tools_meta::*;
-/// #[ derive( Deref, DerefMut ) ]
+/// # use derive_tools_meta::DerefMut;
+/// #[ derive( DerefMut ) ]
 /// pub struct IsTransparent( bool );
-/// ```
 ///
-/// Instead of this
-///
-/// ```rust
-/// pub struct IsTransparent( bool );
-/// impl core::ops::Deref for IsTransparent
+/// impl ::core::ops::Deref for IsTransparent
 /// {
 ///   type Target = bool;
 ///   #[ inline( always ) ]
@@ -300,7 +295,22 @@ pub fn deref( input : proc_macro::TokenStream ) -> proc_macro::TokenStream
 ///     &self.0
 ///   }
 /// }
-/// impl core::ops::DerefMut for IsTransparent
+/// ```
+///
+/// Instead of this
+///
+/// ```rust
+/// pub struct IsTransparent( bool );
+/// impl ::core::ops::Deref for IsTransparent
+/// {
+///   type Target = bool;
+///   #[ inline( always ) ]
+///   fn deref( &self ) -> &Self::Target
+///   {
+///     &self.0
+///   }
+/// }
+/// impl ::core::ops::DerefMut for IsTransparent
 /// {
 ///   #[ inline( always ) ]
 ///   fn deref_mut( &mut self ) -> &mut Self::Target


### PR DESCRIPTION
The PR fixes `deref_mut` tests that don't compile due to disabled `derive_deref` feature.