### PR TITLE
READY (willbe): bugfix: toolchain without `-` in the name

### DIFF
--- a/module/move/willbe/src/entity/channel.rs
+++ b/module/move/willbe/src/entity/channel.rs
@@ -66,8 +66,9 @@ mod private
     let list = report
     .out
     .lines()
-    .map( | l | l.split_once( '-' ).unwrap().0 )
-    .filter_map( | c | match c
+    // toolchain with a name without `-` may exist, but we are looking at specific ones
+    .filter_map( | l | l.split_once( '-' ) )
+    .filter_map( |( c, _ ) | match c
     {
       "stable" => Some( Channel::Stable ),
       "nightly" => Some( Channel::Nightly ),


### PR DESCRIPTION
Bug:
unwrap on a `None` value when you have toolchain without `-` in the name(E.g. `solana`)