### PR TITLE
READY: fixed published version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,9 +381,9 @@ default-features = false
 
 [workspace.dependencies.process_tools_published]
 package = "process_tools"
-version = "~0.2.0"
+version = "~0.7.0"
+path = "module/core/process_tools"
 default-features = false
-
 
 ## test
 


### PR DESCRIPTION
This PR is related to the problem with workflow.
It changes the version of the `process_tools` crate, because there is an error in published version.