### PR TITLE
READY(format_tools): fixed tests

### DIFF
--- a/module/core/format_tools/Readme.md
+++ b/module/core/format_tools/Readme.md
@@ -15,66 +15,70 @@ Using the `to_string_with_fallback` macro to convert values to strings with a pr
 ```rust
 fn main()
 {
-  // Import necessary traits and the macro from the `format_tools` crate.
-  use core::fmt;
-  use format_tools::
+  #[ cfg( feature = "enabled" ) ]
   {
-    WithDebug,
-    WithDisplay,
-    to_string_with_fallback,
-  };
 
-  // Define a struct that implements both Debug and Display traits.
-  struct Both;
-
-  // Implement the Debug trait for the Both struct.
-  impl fmt::Debug for Both
-  {
-    fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+    // Import necessary traits and the macro from the `format_tools` crate.
+    use core::fmt;
+    use format_tools::
     {
-      write!( f, "This is debug" )
-    }
-  }
+      WithDebug,
+      WithDisplay,
+      to_string_with_fallback,
+    };
 
-  // Implement the Display trait for the Both struct.
-  impl fmt::Display for Both
-  {
-    fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+    // Define a struct that implements both Debug and Display traits.
+    struct Both;
+
+    // Implement the Debug trait for the Both struct.
+    impl fmt::Debug for Both
     {
-      write!( f, "This is display" )
+      fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+      {
+        write!( f, "This is debug" )
+      }
     }
-  }
 
-  // Define a struct that implements only the Debug trait.
-  struct OnlyDebug;
-
-  // Implement the Debug trait for the OnlyDebug struct.
-  impl fmt::Debug for OnlyDebug
-  {
-    fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+    // Implement the Display trait for the Both struct.
+    impl fmt::Display for Both
     {
-      write!( f, "This is debug" )
+      fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+      {
+        write!( f, "This is display" )
+      }
     }
+
+    // Define a struct that implements only the Debug trait.
+    struct OnlyDebug;
+
+    // Implement the Debug trait for the OnlyDebug struct.
+    impl fmt::Debug for OnlyDebug
+    {
+      fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+      {
+        write!( f, "This is debug" )
+      }
+    }
+
+    // Example usage: Using Both which implements both Debug and Display.
+    let src = Both;
+    // Convert the struct to a string using `to_string_with_fallback` macro.
+    // The primary formatting method WithDisplay is used.
+    let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
+    let exp = "This is display".to_string();
+    // Assert that the result matches the expected value.
+    assert_eq!( got, exp );
+
+    // Example usage: Using OnlyDebug which implements only Debug.
+    let src = OnlyDebug;
+    // Convert the struct to a string using `to_string_with_fallback` macro.
+    // The primary formatting method WithDisplay is not available, so the fallback WithDebug is used.
+    let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
+    let exp = "This is debug".to_string();
+    // Assert that the result matches the expected value.
+    assert_eq!( got, exp );
+    
   }
-
-  // Example usage: Using Both which implements both Debug and Display.
-  let src = Both;
-  // Convert the struct to a string using `to_string_with_fallback` macro.
-  // The primary formatting method WithDisplay is used.
-  let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
-  let exp = "This is display".to_string();
-  // Assert that the result matches the expected value.
-  assert_eq!( got, exp );
-
-  // Example usage: Using OnlyDebug which implements only Debug.
-  let src = OnlyDebug;
-  // Convert the struct to a string using `to_string_with_fallback` macro.
-  // The primary formatting method WithDisplay is not available, so the fallback WithDebug is used.
-  let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
-  let exp = "This is debug".to_string();
-  // Assert that the result matches the expected value.
-  assert_eq!( got, exp );
-
 }
 ```
 

--- a/module/core/format_tools/examples/format_tools_trivial.rs
+++ b/module/core/format_tools/examples/format_tools_trivial.rs
@@ -5,64 +5,68 @@
 
 fn main()
 {
-  // Import necessary traits and the macro from the `format_tools` crate.
-  use core::fmt;
-  use format_tools::
+  #[ cfg( feature = "enabled" ) ]
   {
-    WithDebug,
-    WithDisplay,
-    to_string_with_fallback,
-  };
 
-  // Define a struct that implements both Debug and Display traits.
-  struct Both;
-
-  // Implement the Debug trait for the Both struct.
-  impl fmt::Debug for Both
-  {
-    fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+    // Import necessary traits and the macro from the `format_tools` crate.
+    use core::fmt;
+    use format_tools::
     {
-      write!( f, "This is debug" )
-    }
-  }
+      WithDebug,
+      WithDisplay,
+      to_string_with_fallback,
+    };
 
-  // Implement the Display trait for the Both struct.
-  impl fmt::Display for Both
-  {
-    fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+    // Define a struct that implements both Debug and Display traits.
+    struct Both;
+
+    // Implement the Debug trait for the Both struct.
+    impl fmt::Debug for Both
     {
-      write!( f, "This is display" )
+      fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+      {
+        write!( f, "This is debug" )
+      }
     }
-  }
 
-  // Define a struct that implements only the Debug trait.
-  struct OnlyDebug;
-
-  // Implement the Debug trait for the OnlyDebug struct.
-  impl fmt::Debug for OnlyDebug
-  {
-    fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+    // Implement the Display trait for the Both struct.
+    impl fmt::Display for Both
     {
-      write!( f, "This is debug" )
+      fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+      {
+        write!( f, "This is display" )
+      }
     }
+
+    // Define a struct that implements only the Debug trait.
+    struct OnlyDebug;
+
+    // Implement the Debug trait for the OnlyDebug struct.
+    impl fmt::Debug for OnlyDebug
+    {
+      fn fmt( &self, f : &mut fmt::Formatter< '_ > ) -> fmt::Result
+      {
+        write!( f, "This is debug" )
+      }
+    }
+
+    // Example usage: Using Both which implements both Debug and Display.
+    let src = Both;
+    // Convert the struct to a string using `to_string_with_fallback` macro.
+    // The primary formatting method WithDisplay is used.
+    let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
+    let exp = "This is display".to_string();
+    // Assert that the result matches the expected value.
+    assert_eq!( got, exp );
+
+    // Example usage: Using OnlyDebug which implements only Debug.
+    let src = OnlyDebug;
+    // Convert the struct to a string using `to_string_with_fallback` macro.
+    // The primary formatting method WithDisplay is not available, so the fallback WithDebug is used.
+    let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
+    let exp = "This is debug".to_string();
+    // Assert that the result matches the expected value.
+    assert_eq!( got, exp );
+    
   }
-
-  // Example usage: Using Both which implements both Debug and Display.
-  let src = Both;
-  // Convert the struct to a string using `to_string_with_fallback` macro.
-  // The primary formatting method WithDisplay is used.
-  let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
-  let exp = "This is display".to_string();
-  // Assert that the result matches the expected value.
-  assert_eq!( got, exp );
-
-  // Example usage: Using OnlyDebug which implements only Debug.
-  let src = OnlyDebug;
-  // Convert the struct to a string using `to_string_with_fallback` macro.
-  // The primary formatting method WithDisplay is not available, so the fallback WithDebug is used.
-  let got = to_string_with_fallback!( WithDisplay, WithDebug, &src );
-  let exp = "This is debug".to_string();
-  // Assert that the result matches the expected value.
-  assert_eq!( got, exp );
-
 }


### PR DESCRIPTION
The example did not compile because `WithDebug`, `WithDisplay`, and `to_string_with_fallback` are under the `enabled` feature. The example itself was without features, so when tests were running the tests with the `no_default_features --feature enabled` parameter failed to compile. This PR placed the example code under the `enabled` feature. And now there are no compilation errors.