### PR TITLE
READY: fix mod_interface_meta for udeps

### DIFF
--- a/module/core/mod_interface_meta/Cargo.toml
+++ b/module/core/mod_interface_meta/Cargo.toml
@@ -41,6 +41,9 @@ enabled = []
 [lib]
 proc-macro = true
 
+[package.metadata.cargo-udeps.ignore]
+normal = [ "derive_tools" ]
+
 [dependencies]
 macro_tools = { workspace = true }
 derive_tools = { workspace = true, features = [ "enabled", "derive_is_variant" ] }


### PR DESCRIPTION
```shell
Note: They might be false-positive.
      For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
```